### PR TITLE
feat: improve export filename by using conversation title

### DIFF
--- a/src/main/managers/exportManager.ts
+++ b/src/main/managers/exportManager.ts
@@ -140,7 +140,10 @@ export default class ExportManager {
 
         const { filePath, canceled } = await dialog.showSaveDialog({
             title: 'Save Chat as Markdown',
-            defaultPath: path.join(app.getPath('downloads'), `${data.title.replace(/[/\\?%*:|"<>]/g, '-')}.md`),
+            defaultPath: path.join(
+                app.getPath('downloads'),
+                `${data.title.replace(/\s+/g, '_').replace(/[/\\?%*:|"<>]/g, '-')}.md`
+            ),
             filters: [{ name: 'Markdown Files', extensions: ['md'] }],
         });
 
@@ -162,7 +165,10 @@ export default class ExportManager {
 
         const { filePath, canceled } = await dialog.showSaveDialog({
             title: 'Save Chat as PDF',
-            defaultPath: path.join(app.getPath('downloads'), `${data.title.replace(/[/\\?%*:|"<>]/g, '-')}.pdf`),
+            defaultPath: path.join(
+                app.getPath('downloads'),
+                `${data.title.replace(/\s+/g, '_').replace(/[/\\?%*:|"<>]/g, '-')}.pdf`
+            ),
             filters: [{ name: 'PDF Files', extensions: ['pdf'] }],
         });
 

--- a/src/main/utils/geminiSelectors.ts
+++ b/src/main/utils/geminiSelectors.ts
@@ -148,6 +148,22 @@ export const GeminiSelectors = {
          */
         description: 'Delay timings for DOM interactions',
     },
+
+    /**
+     * Conversation title configuration.
+     * Used for determining the default filename for exports.
+     */
+    conversationTitle: {
+        /**
+         * CSS selectors for finding the conversation title.
+         */
+        selectors: ['.conversation-title', 'span.conversation-title'] as const,
+
+        /**
+         * Description for logging/debugging.
+         */
+        description: 'Conversation title element',
+    },
 } as const;
 
 /**
@@ -224,3 +240,4 @@ export const GEMINI_SUBMIT_DELAY_MS = GeminiSelectors.timing.submitDelayMs;
 export const GEMINI_MICROPHONE_BUTTON_SELECTORS = GeminiSelectors.microphoneButton.selectors;
 export const GEMINI_ERROR_TOAST_SELECTORS = GeminiSelectors.errorToast.selectors;
 export const GEMINI_MICROPHONE_ERROR_TEXT = GeminiSelectors.errorToast.microphoneErrorText;
+export const GEMINI_CONVERSATION_TITLE_SELECTORS = GeminiSelectors.conversationTitle.selectors;


### PR DESCRIPTION
This is a really small PR that fixes a nit (another small feature gap to `gemini-desk`) that increasingly gnawed at me as I used Gemini-Desktop today...

### Improved Export Filename extraction and formatting

This PR improves the default filename suggested when exporting a conversation to PDF or Markdown. Instead of a generic application name (e.g., "Google Gemini"), it now attempts to extract the actual conversation title directly from the Gemini interface.

#### ✨ Features
- **Smart Title Extraction**: Scrapes the `.conversation-title` element from the Gemini DOM to use as the default filename.
- **Improved Filename Formatting**: Replaces all whitespace with underscores (`_`) to create cleaner, CLI-friendly filenames.
- **Robust Fallbacks**: Automatically falls back to the document title if the specific UI element cannot be found.
- **Sanitization**: Maintains existing logic to replace illegal filesystem characters (like `*`, `:`, `|`) with hyphens.

#### 🛠 Changes
- **[src/main/utils/geminiSelectors.ts](cci:7://file:///home/hightowe/src/tmp/gemini-desk/gemini-desktop-improved-export/src/main/utils/geminiSelectors.ts:0:0-0:0)**: Added new selectors for the conversation title element.
- **[src/main/utils/chatExtraction.ts](cci:7://file:///home/hightowe/src/tmp/gemini-desk/gemini-desktop-improved-export/src/main/utils/chatExtraction.ts:0:0-0:0)**: Updated the injection script to prioritize the DOM-based title over the global `document.title`.
- **[src/main/managers/exportManager.ts](cci:7://file:///home/hightowe/src/tmp/gemini-desk/gemini-desktop-improved-export/src/main/managers/exportManager.ts:0:0-0:0)**: Added regex formatting to swap spaces for underscores in the final output path.
