### PR TITLE
Handle missing Electron preload methods in NotificationSettings

### DIFF
--- a/tests/unit/renderer/NotificationSettings.test.tsx
+++ b/tests/unit/renderer/NotificationSettings.test.tsx
@@ -119,6 +119,25 @@ describe('NotificationSettings (Task 6.5)', () => {
                 expect(mockSetResponseNotificationsEnabled).toHaveBeenCalledWith(false);
             });
         });
+
+        it('reverts toggle state when setter fails', async () => {
+            mockSetResponseNotificationsEnabled.mockRejectedValue(new Error('Setter failed'));
+
+            render(<NotificationSettings />);
+
+            await waitFor(() => {
+                expect(screen.getByTestId('notification-settings')).toBeInTheDocument();
+            });
+
+            const toggleSwitch = screen.getByTestId('response-notifications-toggle-switch');
+            expect(toggleSwitch).toHaveAttribute('aria-checked', 'true');
+
+            fireEvent.click(toggleSwitch);
+
+            await waitFor(() => {
+                expect(toggleSwitch).toHaveAttribute('aria-checked', 'true');
+            });
+        });
     });
 
     describe('API Interactions', () => {
@@ -165,8 +184,9 @@ describe('NotificationSettings (Task 6.5)', () => {
         });
 
         it('handles electronAPI object without notification methods', async () => {
-            clearMockElectronAPI();
-            window.electronAPI = {} as typeof window.electronAPI;
+            setupMockElectronAPI();
+            delete window.electronAPI?.getResponseNotificationsEnabled;
+            delete window.electronAPI?.setResponseNotificationsEnabled;
 
             render(<NotificationSettings />);
 
@@ -181,6 +201,7 @@ describe('NotificationSettings (Task 6.5)', () => {
             await waitFor(() => {
                 expect(toggleSwitch).toHaveAttribute('aria-checked', 'false');
             });
+            expect(mockSetResponseNotificationsEnabled).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when the preload bridge is partially available (i.e. `window.electronAPI` exists but does not expose the response-notifications methods), which previously caused `TypeError` during mount or when toggling the setting.
- Ensure the Options UI finishes loading and remains interactive with a safe local fallback when the main process API is absent or incomplete.

### Description
- Check for `typeof window.electronAPI?.getResponseNotificationsEnabled === 'function'` before calling the getter and fall back to `enabled = true` when it's missing.
- Check for `typeof window.electronAPI?.setResponseNotificationsEnabled === 'function'` before calling the setter and make setter calls a no-op when it's missing while preserving local UI state.
- Update unit tests in `tests/unit/renderer/NotificationSettings.test.tsx` to assert correct behavior when `electronAPI` is undefined and when it exists but lacks the notification methods.

### Testing
- Ran `npx vitest tests/unit/renderer/NotificationSettings.test.tsx --config config/vitest/vitest.config.ts` and all tests in that file passed (12 tests) with the new cases included.
- Ran `npx vitest src/renderer/components/options/OptionsWindow.test.tsx --config config/vitest/vitest.config.ts` to ensure Options integration remained stable and those tests passed (13 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990077ef7c08333a65a7dcb12c65814)