### PR TITLE
Add configurable retries for integration, E2E, and release E2E runs

### DIFF
--- a/config/wdio/wdio.base.conf.js
+++ b/config/wdio/wdio.base.conf.js
@@ -11,6 +11,9 @@ import { fileURLToPath } from 'url';
 import { getAppArgs, linuxServiceConfig } from './electron-args.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const SPEC_FILE_RETRIES = Number(process.env.WDIO_SPEC_FILE_RETRIES ?? 2);
+const SPEC_FILE_RETRY_DELAY_SECONDS = Number(process.env.WDIO_SPEC_FILE_RETRY_DELAY_SECONDS ?? 5);
+const TEST_RETRIES = Number(process.env.WDIO_TEST_RETRIES ?? 2);
 
 export const electronMainPath = path.resolve(__dirname, '../../dist-electron/main/main.cjs');
 
@@ -42,11 +45,12 @@ export const baseConfig = {
     mochaOpts: {
         ui: 'bdd',
         timeout: 90000, // Increased from 60s for stability
+        retries: TEST_RETRIES,
     },
 
     // Retry failed spec files to handle flaky tests
-    specFileRetries: 1,
-    specFileRetriesDelay: 2,
+    specFileRetries: SPEC_FILE_RETRIES,
+    specFileRetriesDelay: SPEC_FILE_RETRY_DELAY_SECONDS,
     specFileRetriesDeferred: false,
 
     // Build the frontend and Electron backend before tests

--- a/config/wdio/wdio.conf.js
+++ b/config/wdio/wdio.conf.js
@@ -15,6 +15,9 @@ import { fileURLToPath } from 'url';
 import { getAppArgs, linuxServiceConfig } from './electron-args.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const SPEC_FILE_RETRIES = Number(process.env.WDIO_SPEC_FILE_RETRIES ?? 2);
+const SPEC_FILE_RETRY_DELAY_SECONDS = Number(process.env.WDIO_SPEC_FILE_RETRY_DELAY_SECONDS ?? 5);
+const TEST_RETRIES = Number(process.env.WDIO_TEST_RETRIES ?? 2);
 
 // Path to the Electron main entry (compiled from TypeScript)
 const electronMainPath = path.resolve(__dirname, '../../dist-electron/main/main.cjs');
@@ -158,12 +161,12 @@ export const config = {
     mochaOpts: {
         ui: 'bdd',
         timeout: 90000, // Increased from 60s for stability
-        retries: 2, // Retry individual tests up to 2 times on failure
+        retries: TEST_RETRIES,
     },
 
     // Retry failed spec files to handle flaky tests
-    specFileRetries: 1,
-    specFileRetriesDelay: 2,
+    specFileRetries: SPEC_FILE_RETRIES,
+    specFileRetriesDelay: SPEC_FILE_RETRY_DELAY_SECONDS,
     specFileRetriesDeferred: false,
 
     // Build the frontend and Electron backend before tests

--- a/config/wdio/wdio.integration.conf.js
+++ b/config/wdio/wdio.integration.conf.js
@@ -8,6 +8,9 @@ dotenvConfig();
 // Get directory of this config file
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const SPEC_FILE_RETRIES = Number(process.env.WDIO_SPEC_FILE_RETRIES ?? 2);
+const SPEC_FILE_RETRY_DELAY_SECONDS = Number(process.env.WDIO_SPEC_FILE_RETRY_DELAY_SECONDS ?? 5);
+const TEST_RETRIES = Number(process.env.WDIO_TEST_RETRIES ?? 2);
 
 // Path to the Electron main entry (compiled from TypeScript)
 const electronMainPath = join(__dirname, '../../dist-electron', 'main/main.cjs');
@@ -45,7 +48,13 @@ export const config = {
     mochaOpts: {
         ui: 'bdd',
         timeout: 60000,
+        retries: TEST_RETRIES,
     },
+
+    // Retry failed spec files to reduce CI timing-related flakes
+    specFileRetries: SPEC_FILE_RETRIES,
+    specFileRetriesDelay: SPEC_FILE_RETRY_DELAY_SECONDS,
+    specFileRetriesDeferred: false,
 
     /**
      * Gets executed before test execution begins.

--- a/config/wdio/wdio.release.conf.js
+++ b/config/wdio/wdio.release.conf.js
@@ -18,6 +18,9 @@ import { fileURLToPath } from 'url';
 import { getAppArgs, linuxServiceConfig } from './electron-args.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const SPEC_FILE_RETRIES = Number(process.env.WDIO_SPEC_FILE_RETRIES ?? 2);
+const SPEC_FILE_RETRY_DELAY_SECONDS = Number(process.env.WDIO_SPEC_FILE_RETRY_DELAY_SECONDS ?? 5);
+const TEST_RETRIES = Number(process.env.WDIO_TEST_RETRIES ?? 2);
 
 /**
  * Get the path to the packaged Electron binary based on the current platform.
@@ -131,11 +134,12 @@ export const config = {
     mochaOpts: {
         ui: 'bdd',
         timeout: 90000,
+        retries: TEST_RETRIES,
     },
 
     // Retry failed spec files
-    specFileRetries: 1,
-    specFileRetriesDelay: 2,
+    specFileRetries: SPEC_FILE_RETRIES,
+    specFileRetriesDelay: SPEC_FILE_RETRY_DELAY_SECONDS,
     specFileRetriesDeferred: false,
 
     // No build step needed - we're testing the already-built package

--- a/openspec/changes/update-test-pipeline-retries/proposal.md
+++ b/openspec/changes/update-test-pipeline-retries/proposal.md
@@ -1,0 +1,20 @@
+# Change: Add CI Retry Controls for Flaky Integration/E2E Suites
+
+## Why
+
+Integration, E2E, and release E2E jobs intermittently fail in CI due to timing instability. We need a temporary resilience mechanism while underlying flakes are investigated.
+
+## What Changes
+
+- Add configurable WebdriverIO spec-level retry support to integration, regular E2E, and release E2E configs.
+- Add configurable Mocha test-level retries in the same suites.
+- Default retry values to CI-friendly settings while allowing environment overrides.
+
+## Impact
+
+- Affected specs: `test-reliability`
+- Affected code:
+    - `config/wdio/wdio.base.conf.js`
+    - `config/wdio/wdio.conf.js`
+    - `config/wdio/wdio.integration.conf.js`
+    - `config/wdio/wdio.release.conf.js`

--- a/openspec/changes/update-test-pipeline-retries/specs/test-reliability/spec.md
+++ b/openspec/changes/update-test-pipeline-retries/specs/test-reliability/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: E2E Test Reliability
+
+The system SHALL reliably verify core features through end-to-end tests without flakiness.
+
+#### Scenario: Startup tests pass without timeout or error
+
+- **Given** the app is built and launched
+- **When** the startup test group runs
+- **Then** all tests in the group pass
+
+#### Scenario: Options tests pass reliably
+
+- **Given** the app is running
+- **When** the options test group runs
+- **Then** it correctly interacts with settings and persists changes
+
+#### Scenario: Menu tests pass reliably
+
+- **Given** the app is running
+- **When** the menu test group runs
+- **Then** menu items trigger expected actions
+
+#### Scenario: Hotkeys tests pass reliably
+
+- **Given** the app is running
+- **When** the hotkeys test group runs
+- **Then** global shortcuts trigger expected actions
+
+#### Scenario: Window tests pass reliably
+
+- **Given** the app is running
+- **When** the window test group runs
+- **Then** window management (bounds, resizing) works as expected
+
+#### Scenario: Tray tests pass reliably
+
+- **Given** the app is running
+- **When** the tray test group runs
+- **Then** tray icon interactions work as expected
+
+#### Scenario: Update tests pass reliably
+
+- **Given** the app is packaged
+- **When** the update test group runs
+- **Then** it correctly checks for updates (simulated or real)
+
+#### Scenario: Stability tests pass reliably
+
+- **Given** the app is running under stress
+- **When** the stability test group runs
+- **Then** the app does not crash or hang
+
+#### Scenario: CI timing instability is mitigated with retries
+
+- **Given** integration, E2E, or release E2E test runs in CI
+- **When** a failure occurs due to transient timing conditions
+- **Then** WebdriverIO retries the affected spec and Mocha retries failed tests based on configured retry values
+- **And** retry values can be overridden via environment variables without modifying test files

--- a/openspec/changes/update-test-pipeline-retries/tasks.md
+++ b/openspec/changes/update-test-pipeline-retries/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: Add Retry Logic to CI-Flaky Test Suites
+
+## 1. WDIO Retry Configuration
+
+- [x] 1.1 Add env-configurable retry constants for spec retries and test retries in shared E2E config.
+- [x] 1.2 Add env-configurable retry constants for integration config.
+- [x] 1.3 Add env-configurable retry constants for full E2E config.
+- [x] 1.4 Add env-configurable retry constants for release E2E config.
+
+## 2. Verification
+
+- [x] 2.1 Validate updated WDIO config files parse with Node syntax checks.


### PR DESCRIPTION
### Motivation

- CI timing instability is causing flaky integration, E2E, and release E2E jobs, so add a configurable, temporary retry mechanism to reduce transient failures while underlying flakes are investigated.

### Description

- Added environment-configurable retry controls to WDIO/Mocha configs by introducing `WDIO_SPEC_FILE_RETRIES`, `WDIO_SPEC_FILE_RETRY_DELAY_SECONDS`, and `WDIO_TEST_RETRIES` and applying them to spec and test retry settings in `config/wdio/wdio.base.conf.js`, `config/wdio/wdio.conf.js`, `config/wdio/wdio.integration.conf.js`, and `config/wdio/wdio.release.conf.js`.
- Wired the new constants into Mocha `retries` and WebdriverIO `specFileRetries`/`specFileRetriesDelay` so both test-level and spec-file-level retries are supported without changing test files.
- Added an OpenSpec change under `openspec/changes/update-test-pipeline-retries` documenting the change with `proposal.md`, `tasks.md`, and a spec delta for `test-reliability`.
- Defaults chosen are CI-friendly but overrideable via environment variables: `WDIO_SPEC_FILE_RETRIES=2`, `WDIO_SPEC_FILE_RETRY_DELAY_SECONDS=5`, and `WDIO_TEST_RETRIES=2`.

### Testing

- Validated updated config syntax by running `node --check` against `config/wdio/wdio.base.conf.js`, `config/wdio/wdio.conf.js`, `config/wdio/wdio.integration.conf.js`, and `config/wdio/wdio.release.conf.js`, and all checks passed.
- No test files were modified as part of this change, so existing test suites remain untouched and will pick up retries via environment or default values when run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699018f7b2c08333864a80384dbddc27)