### PR TITLE
fix: resolve 8 npm audit vulnerabilities via scoped overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,9 +91,9 @@
             }
         },
         "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-            "version": "11.2.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
-            "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+            "version": "11.2.6",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+            "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -101,9 +101,9 @@
             }
         },
         "node_modules/@asamuzakjp/dom-selector": {
-            "version": "6.7.8",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.8.tgz",
-            "integrity": "sha512-stisC1nULNc9oH5lakAj8MH88ZxeGxzyWNDfbdCxvJSJIvDsHNZqYvscGTgy/ysgXWLJPt6K/4t0/GjvtKcFJQ==",
+            "version": "6.8.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+            "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -111,13 +111,13 @@
                 "bidi-js": "^1.0.3",
                 "css-tree": "^3.1.0",
                 "is-potential-custom-element-name": "^1.0.1",
-                "lru-cache": "^11.2.5"
+                "lru-cache": "^11.2.6"
             }
         },
         "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-            "version": "11.2.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
-            "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+            "version": "11.2.6",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+            "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -433,6 +433,19 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@bramus/specificity": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^3.0.0"
+            },
+            "bin": {
+                "specificity": "bin/cli.js"
+            }
+        },
         "node_modules/@csstools/color-helpers": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
@@ -454,9 +467,9 @@
             }
         },
         "node_modules/@csstools/css-calc": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
-            "integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+            "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
             "dev": true,
             "funding": [
                 {
@@ -529,9 +542,9 @@
             }
         },
         "node_modules/@csstools/css-syntax-patches-for-csstree": {
-            "version": "1.0.26",
-            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
-            "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
+            "version": "1.0.27",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
+            "integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
             "dev": true,
             "funding": [
                 {
@@ -599,6 +612,24 @@
             },
             "engines": {
                 "node": ">=10.12.0"
+            }
+        },
+        "node_modules/@electron/asar/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@electron/asar/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
             }
         },
         "node_modules/@electron/asar/node_modules/commander": {
@@ -1183,6 +1214,13 @@
             "engines": {
                 "node": ">=16.4"
             }
+        },
+        "node_modules/@electron/universal/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@electron/universal/node_modules/brace-expansion": {
             "version": "2.0.2",
@@ -1805,6 +1843,24 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@eslint/config-array/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/@eslint/config-array/node_modules/minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1866,6 +1922,24 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
@@ -1932,9 +2006,9 @@
             }
         },
         "node_modules/@exodus/bytes": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.12.0.tgz",
-            "integrity": "sha512-BuCOHA/EJdPN0qQ5MdgAiJSt9fYDHbghlgrj33gRdy/Yp1/FMCDhU6vJfcKrLC0TPWGSrfH3vYXBQWmFHxlddw==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
+            "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1998,9 +2072,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@hapi/tlds": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.4.tgz",
-            "integrity": "sha512-Fq+20dxsxLaUn5jSSWrdtSRcIUba2JquuorF9UW1wIJS5cSUwxIsO2GIhaWynPRflvxSzFN+gxKte2HEW1OuoA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.5.tgz",
+            "integrity": "sha512-Vq/1gnIIsvFUpKlDdfrPd/ssHDpAyBP/baVukh3u2KSG2xoNjsnRNjQiPmuyPPGqsn1cqVWWhtZHfOBaLizFRQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -2444,29 +2518,6 @@
                 "@types/node": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@isaacs/balanced-match": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/@isaacs/brace-expansion": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-            "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@isaacs/balanced-match": "^4.0.1"
-            },
-            "engines": {
-                "node": "20 || >=22"
             }
         },
         "node_modules/@isaacs/cliui": {
@@ -3517,9 +3568,9 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.12.0.tgz",
-            "integrity": "sha512-Xuq42yxcQJ54ti8ZHNzF5snFvtpgXzNToJ1bXUGQRaiO8t+B6UM8sTUJfvV+AJnqtkJU/7hdy6nbKyA12aHtRw==",
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.12.1.tgz",
+            "integrity": "sha512-fXa6uXLxfslBlus3MEpW8S6S9fe5RwmAE5Gd8u3krqOwnkZJV3/lQJiY3LaFdTctLLqJtyMgEUGkbDnRNf6vbQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3527,7 +3578,7 @@
                 "extract-zip": "^2.0.1",
                 "progress": "^2.0.3",
                 "proxy-agent": "^6.5.0",
-                "semver": "^7.7.3",
+                "semver": "^7.7.4",
                 "tar-fs": "^3.1.1",
                 "yargs": "^17.7.2"
             },
@@ -3700,9 +3751,9 @@
             }
         },
         "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.2",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
-            "integrity": "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==",
+            "version": "1.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+            "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -4496,9 +4547,9 @@
             }
         },
         "node_modules/@types/react": {
-            "version": "19.2.13",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
-            "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
+            "version": "19.2.14",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+            "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4794,6 +4845,13 @@
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -4876,16 +4934,16 @@
             }
         },
         "node_modules/@vitejs/plugin-react": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.3.tgz",
-            "integrity": "sha512-NVUnA6gQCl8jfoYqKqQU5Clv0aPw14KkZYCsX6T9Lfu9slI0LOU10OTwFHS/WmptsMMpshNd/1tuWsHQ2Uk+cg==",
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
+            "integrity": "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.29.0",
                 "@babel/plugin-transform-react-jsx-self": "^7.27.1",
                 "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-                "@rolldown/pluginutils": "1.0.0-rc.2",
+                "@rolldown/pluginutils": "1.0.0-rc.3",
                 "@types/babel__core": "^7.20.5",
                 "react-refresh": "^0.18.0"
             },
@@ -5081,19 +5139,19 @@
             }
         },
         "node_modules/@wdio/cli": {
-            "version": "9.23.3",
-            "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.23.3.tgz",
-            "integrity": "sha512-u4mx+uISonKI970LivyEn1qZGJn7izoTKUFUfLX89Y9fOtiASP/6a9KjCdMSw3MZU1cmKZs+yooeO7n0LnQHUA==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.24.0.tgz",
+            "integrity": "sha512-dFs1HNmyXne0pDOYPOHhFcck0BC22z0lMdu6RtTX1C4gHdEYsjTtTH2zsZ5N5BzzsZVSUol2PisuqyLQO5dZIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vitest/snapshot": "^2.1.1",
-                "@wdio/config": "9.23.3",
+                "@wdio/config": "9.24.0",
                 "@wdio/globals": "9.23.0",
                 "@wdio/logger": "9.18.0",
-                "@wdio/protocols": "9.23.3",
-                "@wdio/types": "9.23.3",
-                "@wdio/utils": "9.23.3",
+                "@wdio/protocols": "9.24.0",
+                "@wdio/types": "9.24.0",
+                "@wdio/utils": "9.24.0",
                 "async-exit-hook": "^2.0.1",
                 "chalk": "^5.4.1",
                 "chokidar": "^4.0.0",
@@ -5105,7 +5163,7 @@
                 "lodash.union": "^4.6.0",
                 "read-pkg-up": "^10.0.0",
                 "tsx": "^4.7.2",
-                "webdriverio": "9.23.3",
+                "webdriverio": "9.24.0",
                 "yargs": "^17.7.2"
             },
             "bin": {
@@ -5116,15 +5174,15 @@
             }
         },
         "node_modules/@wdio/config": {
-            "version": "9.23.3",
-            "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.23.3.tgz",
-            "integrity": "sha512-tQCT1R6R3hdib7Qb+82Dxgn/sB+CiR8+GS4zyJh5vU0dzLGeYsCo2B5W89VLItvRjveTmsmh8NOQGV2KH0FHTQ==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.24.0.tgz",
+            "integrity": "sha512-rcHu0eG16rSEmHL0sEKDcr/vYFmGhQ5GOlmlx54r+1sgh6sf136q+kth4169s16XqviWGW3LjZbUfpTK29pGtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@wdio/logger": "9.18.0",
-                "@wdio/types": "9.23.3",
-                "@wdio/utils": "9.23.3",
+                "@wdio/types": "9.24.0",
+                "@wdio/utils": "9.24.0",
                 "deepmerge-ts": "^7.0.3",
                 "glob": "^10.2.2",
                 "import-meta-resolve": "^4.0.0",
@@ -5135,14 +5193,14 @@
             }
         },
         "node_modules/@wdio/dot-reporter": {
-            "version": "9.23.3",
-            "resolved": "https://registry.npmjs.org/@wdio/dot-reporter/-/dot-reporter-9.23.3.tgz",
-            "integrity": "sha512-behiP6+SbQDO51GMtJ120X1vvc2I+qEdmTjfEG66e9hYozcg+iiaaPQd9RnCl8GJiU320APA91FXUGkz2ehSVQ==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@wdio/dot-reporter/-/dot-reporter-9.24.0.tgz",
+            "integrity": "sha512-hZNXnY4EVnDRTedGSlkWQL6sPkxe1zgRzTaam+S7GduF+IOTQXHIsuklfpHLs6mrj3oS+JuKbosodsyvLU7KQA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@wdio/reporter": "9.23.3",
-                "@wdio/types": "9.23.3",
+                "@wdio/reporter": "9.24.0",
+                "@wdio/types": "9.24.0",
                 "chalk": "^5.0.1"
             },
             "engines": {
@@ -5701,18 +5759,18 @@
             }
         },
         "node_modules/@wdio/local-runner": {
-            "version": "9.23.3",
-            "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.23.3.tgz",
-            "integrity": "sha512-ToafGHzdszOn8yc2BqUCAw0w9AX6158WKCHe50czZrHL04Q4eMCaqhb4XHY2wltSPPuubqCiPE2OgRssYi2kdQ==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.24.0.tgz",
+            "integrity": "sha512-SUs5HEGHXEl/fVdkkhY1+of+Dv8AlceulRTpmYMmSR4Nu+tHUXSPkzjoYgVa+xVu0MpVrD+dhTm13hOtlDAlMg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^20.1.0",
                 "@wdio/logger": "9.18.0",
                 "@wdio/repl": "9.16.2",
-                "@wdio/runner": "9.23.3",
-                "@wdio/types": "9.23.3",
-                "@wdio/xvfb": "9.23.3",
+                "@wdio/runner": "9.24.0",
+                "@wdio/types": "9.24.0",
+                "@wdio/xvfb": "9.24.0",
                 "exit-hook": "^4.0.0",
                 "expect-webdriverio": "^5.3.4",
                 "split2": "^4.1.0",
@@ -5740,17 +5798,17 @@
             }
         },
         "node_modules/@wdio/mocha-framework": {
-            "version": "9.23.3",
-            "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.23.3.tgz",
-            "integrity": "sha512-iCgKR69zMq6ATsORM4zoOF1Gk/82uEg5wbaEWQhgjv1TIK+D5VVFLYlVFwMOWcmAuGH4gAIj9TJoWX9cADh3/A==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.24.0.tgz",
+            "integrity": "sha512-zzTfFk79Zx3qZgfbgpJ7o0euzgXIQSCzbfFPjgtEx8u7fvrhB8tbgf+EGPOEGPBOH/X1GvpAfDkhkgZ6roDR2Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^10.0.6",
                 "@types/node": "^20.11.28",
                 "@wdio/logger": "9.18.0",
-                "@wdio/types": "9.23.3",
-                "@wdio/utils": "9.23.3",
+                "@wdio/types": "9.24.0",
+                "@wdio/utils": "9.24.0",
                 "mocha": "^10.3.0"
             },
             "engines": {
@@ -5758,9 +5816,9 @@
             }
         },
         "node_modules/@wdio/protocols": {
-            "version": "9.23.3",
-            "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.23.3.tgz",
-            "integrity": "sha512-QfA3Gfl9/3QRX1FnH7x2+uZrgpkwYcksgk1bxGLzl/E0Qefp3BkhgHAfSB1+iKsiYIw9iFOLVx+x+zh0F4BSeg==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.24.0.tgz",
+            "integrity": "sha512-ozQKYddBLT4TRvU9J+fGrhVUtx3iDAe+KNCJcTDMFMxNSdDMR2xFQdNp8HLHypspk58oXTYCvz6ZYjySthhqsw==",
             "dev": true,
             "license": "MIT"
         },
@@ -5778,15 +5836,15 @@
             }
         },
         "node_modules/@wdio/reporter": {
-            "version": "9.23.3",
-            "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-9.23.3.tgz",
-            "integrity": "sha512-ObIvV+FydWGsvt7kqRBCq5ItAzWhWiWG63t5P0mQKrADCtuJMjrI0Y/IrYQzcv2KnYcmkMKOQLwXFWp8D+D/OA==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-9.24.0.tgz",
+            "integrity": "sha512-0VrEX2uzjrFCHb6fNQDrQe6X7xuQbXUJhy5CGhMZghnPegW0OnKguwUy/vVKJE0HEDMOrR8djteefxJVfOOZpw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^20.1.0",
                 "@wdio/logger": "9.18.0",
-                "@wdio/types": "9.23.3",
+                "@wdio/types": "9.24.0",
                 "diff": "^8.0.2",
                 "object-inspect": "^1.12.0"
             },
@@ -5795,22 +5853,22 @@
             }
         },
         "node_modules/@wdio/runner": {
-            "version": "9.23.3",
-            "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.23.3.tgz",
-            "integrity": "sha512-CnN4JubPmgVjWS9+S4nR8iDrVpjzsrClVlrAkhyG7+GF6PqzqMUpUABkFh7WlBxOATyxky/q6JCqgdFE+teVIA==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.24.0.tgz",
+            "integrity": "sha512-B1ezRtvR/eJCKQSVyLbERpyyMG3bP7RKaQBHT7bNxGsuEuarkUU7cS/T/aB+woZb4UtWotlrBFY4icAS0HqOkA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^20.11.28",
-                "@wdio/config": "9.23.3",
-                "@wdio/dot-reporter": "9.23.3",
+                "@wdio/config": "9.24.0",
+                "@wdio/dot-reporter": "9.24.0",
                 "@wdio/globals": "9.23.0",
                 "@wdio/logger": "9.18.0",
-                "@wdio/types": "9.23.3",
-                "@wdio/utils": "9.23.3",
+                "@wdio/types": "9.24.0",
+                "@wdio/utils": "9.24.0",
                 "deepmerge-ts": "^7.0.3",
-                "webdriver": "9.23.3",
-                "webdriverio": "9.23.3"
+                "webdriver": "9.24.0",
+                "webdriverio": "9.24.0"
             },
             "engines": {
                 "node": ">=18.20.0"
@@ -5829,14 +5887,14 @@
             }
         },
         "node_modules/@wdio/spec-reporter": {
-            "version": "9.23.3",
-            "resolved": "https://registry.npmjs.org/@wdio/spec-reporter/-/spec-reporter-9.23.3.tgz",
-            "integrity": "sha512-4sARJ7ijOHGYo1mm4IRJttFiNYXYy3rf8YLPxKAlr1cKiYMHNtfZNcPiUsD4iU80TpEeP442ueV93ESog1oe4A==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@wdio/spec-reporter/-/spec-reporter-9.24.0.tgz",
+            "integrity": "sha512-I3HExQKvF5u+RUcwImk9JMiuBgo2MmuKDj3Y0oSRwSw0TxQX0nqVvt8udlVG6XJpOD+e4EqlCGWbFfMezi8iTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@wdio/reporter": "9.23.3",
-                "@wdio/types": "9.23.3",
+                "@wdio/reporter": "9.24.0",
+                "@wdio/types": "9.24.0",
                 "chalk": "^5.1.2",
                 "easy-table": "^1.2.0",
                 "pretty-ms": "^9.0.0"
@@ -5846,9 +5904,9 @@
             }
         },
         "node_modules/@wdio/types": {
-            "version": "9.23.3",
-            "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.23.3.tgz",
-            "integrity": "sha512-Ufjh06DAD7cGTMORUkq5MTZLw1nAgBSr2y8OyiNNuAfPGCwHEU3EwEfhG/y0V7S7xT5pBxliqWi7AjRrCgGcIA==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.24.0.tgz",
+            "integrity": "sha512-PYYunNl8Uq1r8YMJAK6ReRy/V/XIrCSyj5cpCtR5EqCL6heETOORFj7gt4uPnzidfgbtMBcCru0LgjjlMiH1UQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5859,15 +5917,15 @@
             }
         },
         "node_modules/@wdio/utils": {
-            "version": "9.23.3",
-            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.23.3.tgz",
-            "integrity": "sha512-LO/cTpOcb3r49psjmWTxjFduHUMHDOhVfSzL1gfBCS5cGv6h3hAWOYw/94OrxLn1SIOgZu/hyLwf3SWeZB529g==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.24.0.tgz",
+            "integrity": "sha512-6WhtzC5SNCGRBTkaObX6A07Ofnnyyf+TQH/d/fuhZRqvBknrP4AMMZF+PFxGl1fwdySWdBn+gV2QLE+52Byowg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@puppeteer/browsers": "^2.2.0",
                 "@wdio/logger": "9.18.0",
-                "@wdio/types": "9.23.3",
+                "@wdio/types": "9.24.0",
                 "decamelize": "^6.0.0",
                 "deepmerge-ts": "^7.0.3",
                 "edgedriver": "^6.1.2",
@@ -5885,9 +5943,9 @@
             }
         },
         "node_modules/@wdio/xvfb": {
-            "version": "9.23.3",
-            "resolved": "https://registry.npmjs.org/@wdio/xvfb/-/xvfb-9.23.3.tgz",
-            "integrity": "sha512-m0uITSBWk5hZyBdCFChpU05rkZCrTlu19qOHlSoJq19HX7m7mLbAz3tuu4SE+6jSw/E16I99zTC5S1bpxj7bEg==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@wdio/xvfb/-/xvfb-9.24.0.tgz",
+            "integrity": "sha512-eK0rUZeR+wlFapm2cb7OQ1LwC/nHmdo7eX02B2Dme7uQGF3+/ILkDTm5B0RYpGUbM3ktw3d0fhcwqqeNNH9KIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5908,14 +5966,11 @@
             }
         },
         "node_modules/@zip.js/zip.js": {
-            "version": "2.8.17",
-            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.17.tgz",
-            "integrity": "sha512-3UdSsm9D9wy8+Oclimd3W9mWqiGptbrL7kBxAdXr/FLN2FSmNnAiyRol93heAffLGDzNwY5nnvDEjMmo8JbeeA==",
+            "version": "2.8.20",
+            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.20.tgz",
+            "integrity": "sha512-oJzVhK9gnSKD++WLG37QEgeTgm5W8XUYmNv0EhOxytSr85vXn9EMpOoKNTK3yWDLa55Z0MovKW/6RNeh9OUmnA==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "dependencies": {
-                "web-worker": "^1.5.0"
-            },
             "engines": {
                 "bun": ">=0.7.0",
                 "deno": ">=1.0.0",
@@ -5979,7 +6034,7 @@
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
             "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 14"
@@ -5989,7 +6044,7 @@
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -6262,13 +6317,13 @@
             }
         },
         "node_modules/app-builder-lib/node_modules/isexe": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.4.tgz",
-            "integrity": "sha512-jCErc4h4RnTPjFq53G4whhjAMbUAqinGrCrTT4dmMNyi4zTthK+wphqbRLJtL4BN/Mq7Zzltr0m/b1X0m7PGFQ==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+            "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">=20"
+                "node": ">=18"
             }
         },
         "node_modules/app-builder-lib/node_modules/semver": {
@@ -6611,20 +6666,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/asn1": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-            "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
         "node_modules/assert-plus": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "engines": {
@@ -6764,23 +6810,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/aws4": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-            "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/axios": {
             "version": "1.13.5",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
@@ -6794,9 +6823,9 @@
             }
         },
         "node_modules/b4a": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-            "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.4.tgz",
+            "integrity": "sha512-u20zJLDaSWpxaZ+zaAkEIB2dZZ1o+DF4T/MRbmsvGp9nletHOyiai19OzX1fF8xUBYsO1bPXxODvcd0978pnug==",
             "dev": true,
             "license": "Apache-2.0",
             "peerDependencies": {
@@ -6809,11 +6838,43 @@
             }
         },
         "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
+            "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
             "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "jackspeak": "^4.2.3"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/balanced-match/node_modules/@isaacs/cliui": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+            "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+            "devOptional": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/balanced-match/node_modules/jackspeak": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+            "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+            "devOptional": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^9.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/bare-events": {
             "version": "2.8.2",
@@ -6831,9 +6892,9 @@
             }
         },
         "node_modules/bare-fs": {
-            "version": "4.5.3",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.3.tgz",
-            "integrity": "sha512-9+kwVx8QYvt3hPWnmb19tPnh38c6Nihz8Lx3t0g9+4GoIf3/fTgYwM4Z6NxgI+B9elLQA7mLE9PpqcWtOMRDiQ==",
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.4.tgz",
+            "integrity": "sha512-POK4oplfA7P7gqvetNmCs4CNtm9fNsx+IAh7jH7GgU0OJdge2rso0R20TNWVq6VoWcCvsTdlNDaleLHGaKx8CA==",
             "dev": true,
             "license": "Apache-2.0",
             "optional": true,
@@ -6953,16 +7014,6 @@
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "dependencies": {
-                "tweetnacl": "^0.14.3"
-            }
-        },
         "node_modules/before-after-hook": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
@@ -7046,14 +7097,16 @@
             "optional": true
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+            "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -7434,9 +7487,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001769",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-            "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+            "version": "1.0.30001770",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
+            "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
             "dev": true,
             "funding": [
                 {
@@ -7453,13 +7506,6 @@
                 }
             ],
             "license": "CC-BY-4.0"
-        },
-        "node_modules/caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-            "license": "Apache-2.0",
-            "optional": true
         },
         "node_modules/chai": {
             "version": "6.2.2",
@@ -7859,16 +7905,6 @@
                 "node": ">= 10.0.0"
             }
         },
-        "node_modules/code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -8022,7 +8058,7 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/concurrently": {
@@ -8127,7 +8163,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/crc": {
@@ -8338,25 +8374,25 @@
             "license": "MIT"
         },
         "node_modules/cssstyle": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
-            "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.0.1.tgz",
+            "integrity": "sha512-IoJs7La+oFp/AB033wBStxNOJt4+9hHMxsXUPANcoXL2b3W4DZKghlJ2cI/eyeRZIQ9ysvYEorVhjrcYctWbog==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@asamuzakjp/css-color": "^4.1.1",
-                "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+                "@asamuzakjp/css-color": "^4.1.2",
+                "@csstools/css-syntax-patches-for-csstree": "^1.0.26",
                 "css-tree": "^3.1.0",
-                "lru-cache": "^11.2.4"
+                "lru-cache": "^11.2.5"
             },
             "engines": {
                 "node": ">=20"
             }
         },
         "node_modules/cssstyle/node_modules/lru-cache": {
-            "version": "11.2.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
-            "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+            "version": "11.2.6",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+            "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -8369,19 +8405,6 @@
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "assert-plus": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
         },
         "node_modules/data-uri-to-buffer": {
             "version": "6.0.2",
@@ -8729,6 +8752,24 @@
                 "p-limit": "^3.1.0 "
             }
         },
+        "node_modules/dir-compare/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/dir-compare/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/dir-compare/node_modules/minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -8918,9 +8959,9 @@
             }
         },
         "node_modules/dotenv": {
-            "version": "17.2.4",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.4.tgz",
-            "integrity": "sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==",
+            "version": "17.3.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+            "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -9000,17 +9041,6 @@
                 "wcwidth": "^1.0.1"
             }
         },
-        "node_modules/ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
-        },
         "node_modules/edge-paths": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
@@ -9053,9 +9083,9 @@
             }
         },
         "node_modules/edgedriver/node_modules/isexe": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.4.tgz",
-            "integrity": "sha512-jCErc4h4RnTPjFq53G4whhjAMbUAqinGrCrTT4dmMNyi4zTthK+wphqbRLJtL4BN/Mq7Zzltr0m/b1X0m7PGFQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -9063,13 +9093,13 @@
             }
         },
         "node_modules/edgedriver/node_modules/which": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
-            "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "isexe": "^3.1.1"
+                "isexe": "^4.0.0"
             },
             "bin": {
                 "node-which": "bin/which.js"
@@ -9095,9 +9125,9 @@
             }
         },
         "node_modules/electron": {
-            "version": "39.5.1",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-39.5.1.tgz",
-            "integrity": "sha512-6s/sBQar+bbW59XSqohZj04MPic+kdVUAWjLbfQB/uLOeNw9jWX5FHaTxpHK29Xp3mKOHef7wErsjwMyCuWltg==",
+            "version": "39.6.0",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-39.6.0.tgz",
+            "integrity": "sha512-KQK3sJ6JCyymY3HQxV0N/bVBQwKQETRW0N/+OYcrL9H6tZhpmTSaZY3qSxcruWrPIuouvoiP3Vk/JKUpw05ZIw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -9455,9 +9485,9 @@
             }
         },
         "node_modules/electron/node_modules/@types/node": {
-            "version": "22.19.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.10.tgz",
-            "integrity": "sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw==",
+            "version": "22.19.11",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+            "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9475,7 +9505,6 @@
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
             "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -9556,7 +9585,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
             "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/error-ex": {
@@ -9987,6 +10016,24 @@
                 "eslint": ">=9"
             }
         },
+        "node_modules/eslint-plugin-react/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/eslint-plugin-react/node_modules/minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -10044,6 +10091,24 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/eslint/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/eslint/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
             }
         },
         "node_modules/eslint/node_modules/chalk": {
@@ -10355,15 +10420,8 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
             "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0"
-        },
-        "node_modules/extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/extract-zip": {
             "version": "2.0.1",
@@ -10464,7 +10522,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-fifo": {
@@ -10478,7 +10536,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
@@ -10489,9 +10547,9 @@
             "license": "MIT"
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.5.tgz",
-            "integrity": "sha512-JeaA2Vm9ffQKp9VjvfzObuMCjUYAp5WDYhRYL5LrBPY/jUDlUtOvDfot0vKSkB9tuX885BDHjtw4fZadD95wnA==",
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+            "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
             "dev": true,
             "funding": [
                 {
@@ -10521,7 +10579,7 @@
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
@@ -10580,6 +10638,13 @@
             "dependencies": {
                 "minimatch": "^5.0.1"
             }
+        },
+        "node_modules/filelist/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/filelist/node_modules/brace-expansion": {
             "version": "2.0.2",
@@ -10830,16 +10895,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/form-data": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -10909,7 +10964,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
             "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^7.0.3"
@@ -10922,7 +10977,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/fsevents": {
@@ -11444,16 +11499,6 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "assert-plus": "^1.0.0"
-            }
-        },
         "node_modules/glob": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -11488,6 +11533,13 @@
             "engines": {
                 "node": ">=10.13.0"
             }
+        },
+        "node_modules/glob/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/glob/node_modules/brace-expansion": {
             "version": "2.0.2",
@@ -11629,31 +11681,6 @@
             "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-            "license": "ISC",
-            "optional": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/har-validator": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-            "deprecated": "this library is no longer supported",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "ajv": "^6.12.3",
-                "har-schema": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/has-bigints": {
             "version": "1.1.0",
@@ -11889,14 +11916,14 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
             "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/http-proxy-agent": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
             "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.0",
@@ -11904,22 +11931,6 @@
             },
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-            },
-            "engines": {
-                "node": ">=0.8",
-                "npm": ">=1.3.7"
             }
         },
         "node_modules/http2-wrapper": {
@@ -11940,7 +11951,7 @@
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
             "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.2",
@@ -11998,7 +12009,7 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -12077,7 +12088,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
@@ -12111,7 +12122,7 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
             "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "once": "^1.3.0",
@@ -12178,7 +12189,7 @@
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
             "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -12774,13 +12785,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/is-unicode-supported": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -12866,13 +12870,6 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "devOptional": true,
             "license": "ISC"
-        },
-        "node_modules/isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.2",
@@ -13377,24 +13374,18 @@
             "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-2.0.5.tgz",
             "integrity": "sha512-TzO/62Hxeb26QMb4IGlI/5X+QLr9Uqp1FPkwp2+KOICW+Q+vSuFj61c8pkT6wAns4WcK56X7CmSHhJeDGWOqxQ=="
         },
-        "node_modules/jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/jsdom": {
-            "version": "28.0.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.0.0.tgz",
-            "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
+            "version": "28.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+            "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@acemir/cssom": "^0.9.31",
-                "@asamuzakjp/dom-selector": "^6.7.6",
+                "@asamuzakjp/dom-selector": "^6.8.1",
+                "@bramus/specificity": "^2.4.2",
                 "@exodus/bytes": "^1.11.0",
-                "cssstyle": "^5.3.7",
+                "cssstyle": "^6.0.1",
                 "data-urls": "^7.0.0",
                 "decimal.js": "^10.6.0",
                 "html-encoding-sniffer": "^6.0.0",
@@ -13405,7 +13396,7 @@
                 "saxes": "^6.0.0",
                 "symbol-tree": "^3.2.4",
                 "tough-cookie": "^6.0.0",
-                "undici": "^7.20.0",
+                "undici": "^7.21.0",
                 "w3c-xmlserializer": "^5.0.0",
                 "webidl-conversions": "^8.0.1",
                 "whatwg-mimetype": "^5.0.0",
@@ -13454,18 +13445,11 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/json-schema": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-            "license": "(AFL-2.1 OR BSD-3-Clause)",
-            "optional": true
-        },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
@@ -13479,6 +13463,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+            "dev": true,
             "license": "ISC",
             "optional": true
         },
@@ -13503,47 +13488,6 @@
             "license": "MIT",
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/jsprim": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-            "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.4.0",
-                "verror": "1.10.0"
-            },
-            "engines": {
-                "node": ">=0.6.0"
-            }
-        },
-        "node_modules/jsprim/node_modules/extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-            "engines": [
-                "node >=0.6.0"
-            ],
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/jsprim/node_modules/verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-            "engines": [
-                "node >=0.6.0"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
             }
         },
         "node_modules/jsx-ast-utils": {
@@ -14387,13 +14331,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/make-asynchronous/node_modules/web-worker": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
-            "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==",
-            "dev": true,
-            "license": "Apache-2.0"
-        },
         "node_modules/make-dir": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -14452,9 +14389,9 @@
             "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g=="
         },
         "node_modules/markdown-it": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14483,9 +14420,9 @@
             }
         },
         "node_modules/marked": {
-            "version": "17.0.1",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
-            "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.2.tgz",
+            "integrity": "sha512-s5HZGFQea7Huv5zZcAGhJLT3qLpAfnY7v7GWkICUr0+Wd5TFEtdlRR2XUL5Gg+RH7u2Df595ifrxR03mBaw7gA==",
             "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
@@ -14649,13 +14586,13 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
-            "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
-            "dev": true,
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
+            "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
+            "devOptional": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "@isaacs/brace-expansion": "^5.0.1"
+                "brace-expansion": "^5.0.2"
             },
             "engines": {
                 "node": "20 || >=22"
@@ -14688,7 +14625,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
             "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^7.0.3"
@@ -14719,7 +14656,7 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
             "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^3.0.0"
@@ -14732,7 +14669,7 @@
             "version": "3.3.6",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -14745,14 +14682,14 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC"
         },
         "node_modules/minipass-pipeline": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
             "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^3.0.0"
@@ -14765,7 +14702,7 @@
             "version": "3.3.6",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -14778,7 +14715,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC"
         },
         "node_modules/minipass-sized": {
@@ -14899,6 +14836,13 @@
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
+        },
+        "node_modules/mocha/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/mocha/node_modules/brace-expansion": {
             "version": "2.0.2",
@@ -15171,7 +15115,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
             "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -15277,13 +15221,13 @@
             }
         },
         "node_modules/node-gyp/node_modules/isexe": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.4.tgz",
-            "integrity": "sha512-jCErc4h4RnTPjFq53G4whhjAMbUAqinGrCrTT4dmMNyi4zTthK+wphqbRLJtL4BN/Mq7Zzltr0m/b1X0m7PGFQ==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+            "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">=20"
+                "node": ">=18"
             }
         },
         "node_modules/node-gyp/node_modules/semver": {
@@ -15463,13 +15407,13 @@
             }
         },
         "node_modules/node-llama-cpp/node_modules/isexe": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.4.tgz",
-            "integrity": "sha512-jCErc4h4RnTPjFq53G4whhjAMbUAqinGrCrTT4dmMNyi4zTthK+wphqbRLJtL4BN/Mq7Zzltr0m/b1X0m7PGFQ==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+            "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
             "license": "BlueOak-1.0.0",
             "optional": true,
             "engines": {
-                "node": ">=20"
+                "node": ">=18"
             }
         },
         "node_modules/node-llama-cpp/node_modules/jsonfile": {
@@ -15794,31 +15738,11 @@
                 "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
         },
-        "node_modules/number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -15960,7 +15884,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -16226,7 +16150,7 @@
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
             "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -16458,7 +16382,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -16559,13 +16483,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -16577,7 +16494,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -16835,7 +16752,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/progress": {
@@ -16852,7 +16769,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
             "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "err-code": "^2.0.2",
@@ -16866,7 +16783,7 @@
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
             "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -16957,19 +16874,6 @@
             "devOptional": true,
             "license": "MIT"
         },
-        "node_modules/psl": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-            "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "punycode": "^2.3.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/lupomontero"
-            }
-        },
         "node_modules/pump": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -16985,7 +16889,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -17070,16 +16974,6 @@
                 }
             ],
             "license": "MIT"
-        },
-        "node_modules/qs": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-            "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "engines": {
-                "node": ">=0.6"
-            }
         },
         "node_modules/query-selector-shadow-dom": {
             "version": "1.0.1",
@@ -17504,6 +17398,13 @@
                 "minimatch": "^5.1.0"
             }
         },
+        "node_modules/readdir-glob/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/readdir-glob/node_modules/brace-expansion": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -17584,6 +17485,24 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/recursive-readdir/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/recursive-readdir/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/recursive-readdir/node_modules/minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -17653,68 +17572,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/request": {
-            "version": "2.88.2",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-            "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.5.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/request/node_modules/form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 0.12"
-            }
-        },
-        "node_modules/request/node_modules/tough-cookie": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "dependencies": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.8"
             }
         },
         "node_modules/require-directory": {
@@ -17896,6 +17753,26 @@
                 "rimraf": "bin.js"
             }
         },
+        "node_modules/rimraf/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/rimraf/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/rimraf/node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -18051,7 +17928,6 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -18436,9 +18312,9 @@
             }
         },
         "node_modules/simple-git": {
-            "version": "3.30.0",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.30.0.tgz",
-            "integrity": "sha512-q6lxyDsCmEal/MEGhP1aVyQ3oxnagGlBDOVSIB4XUVLl1iZh0Pah6ebC9V4xBap/RfgP2WlI8EKs0WS0rMEJHg==",
+            "version": "3.31.1",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.31.1.tgz",
+            "integrity": "sha512-oiWP4Q9+kO8q9hHqkX35uuHmxiEbZNTrZ5IPxgMGrJwN76pzjm/jabkZO0ItEcqxAincqGAzL3QHSaHt4+knBg==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -18531,7 +18407,7 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6.0.0",
@@ -18555,7 +18431,7 @@
             "version": "2.8.7",
             "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
             "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "ip-address": "^10.0.1",
@@ -18570,7 +18446,7 @@
             "version": "8.0.5",
             "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
             "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.2",
@@ -18694,32 +18570,6 @@
             "dev": true,
             "license": "BSD-3-Clause",
             "optional": true
-        },
-        "node_modules/sshpk": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-            "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            },
-            "bin": {
-                "sshpk-conv": "bin/sshpk-conv",
-                "sshpk-sign": "bin/sshpk-sign",
-                "sshpk-verify": "bin/sshpk-verify"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/ssri": {
             "version": "12.0.0",
@@ -19408,9 +19258,9 @@
             }
         },
         "node_modules/text-decoder": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-            "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.6.tgz",
+            "integrity": "sha512-27FeW5GQFDfw0FpwMQhMagB7BztOOlmjcSRi97t2oplhKVTZtp0DZbSegSaXS5IIC6mxMvBG4AR1Sgc6BX3CQg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -19493,7 +19343,7 @@
             "version": "0.2.15",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
             "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
@@ -19712,19 +19562,6 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
-        "node_modules/tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/turndown": {
             "version": "7.2.2",
             "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
@@ -19739,13 +19576,6 @@
             "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
             "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
             "license": "MIT"
-        },
-        "node_modules/tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-            "license": "Unlicense",
-            "optional": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -19852,9 +19682,9 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.28.16",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.16.tgz",
-            "integrity": "sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==",
+            "version": "0.28.17",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.17.tgz",
+            "integrity": "sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -19874,6 +19704,13 @@
             "peerDependencies": {
                 "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
             }
+        },
+        "node_modules/typedoc/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/typedoc/node_modules/brace-expansion": {
             "version": "2.0.2",
@@ -19977,9 +19814,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.21.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
-            "integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
+            "version": "7.22.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+            "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -20091,7 +19928,7 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
@@ -20134,209 +19971,228 @@
                 "node-gyp": "^7.1.2"
             }
         },
-        "node_modules/usocket/node_modules/abbrev": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+        "node_modules/usocket/node_modules/@npmcli/agent": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
+            "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
             "license": "ISC",
-            "optional": true
+            "optional": true,
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.1",
+                "lru-cache": "^11.2.1",
+                "socks-proxy-agent": "^8.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
         },
-        "node_modules/usocket/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-            "license": "MIT",
+        "node_modules/usocket/node_modules/@npmcli/fs": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+            "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/usocket/node_modules/abbrev": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+            "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+            "license": "ISC",
             "optional": true,
             "engines": {
-                "node": ">=0.10.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/usocket/node_modules/aproba": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/usocket/node_modules/are-we-there-yet": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-            "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-            "deprecated": "This package is no longer supported.",
+        "node_modules/usocket/node_modules/cacache": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.3.tgz",
+            "integrity": "sha512-3pUp4e8hv07k1QlijZu6Kn7c9+ZpWWk4j3F8N3xPuCExULobqJydKYOTj1FTq58srkJsXvO7LbGAH4C0ZU3WGw==",
             "license": "ISC",
             "optional": true,
             "dependencies": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-            }
-        },
-        "node_modules/usocket/node_modules/gauge": {
-            "version": "2.7.4",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-            "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
-            "deprecated": "This package is no longer supported.",
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
+                "@npmcli/fs": "^5.0.0",
+                "fs-minipass": "^3.0.0",
+                "glob": "^13.0.0",
+                "lru-cache": "^11.1.0",
+                "minipass": "^7.0.3",
+                "minipass-collect": "^2.0.1",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "p-map": "^7.0.2",
+                "ssri": "^13.0.0",
+                "unique-filename": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/usocket/node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "license": "ISC",
+            "version": "13.0.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.3.tgz",
+            "integrity": "sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==",
+            "license": "BlueOak-1.0.0",
             "optional": true,
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "minimatch": "^10.2.0",
+                "minipass": "^7.1.2",
+                "path-scurry": "^2.0.0"
             },
             "engines": {
-                "node": "*"
+                "node": "20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/usocket/node_modules/is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-            "license": "MIT",
+        "node_modules/usocket/node_modules/isexe": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "license": "BlueOak-1.0.0",
             "optional": true,
-            "dependencies": {
-                "number-is-nan": "^1.0.0"
-            },
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=20"
             }
         },
-        "node_modules/usocket/node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "license": "MIT",
-            "optional": true
+        "node_modules/usocket/node_modules/lru-cache": {
+            "version": "11.2.6",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+            "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+            "license": "BlueOak-1.0.0",
+            "optional": true,
+            "engines": {
+                "node": "20 || >=22"
+            }
         },
-        "node_modules/usocket/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+        "node_modules/usocket/node_modules/make-fetch-happen": {
+            "version": "15.0.3",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.3.tgz",
+            "integrity": "sha512-iyyEpDty1mwW3dGlYXAJqC/azFn5PPvgKVwXayOGBSmKLxhKZ9fg4qIan2ePpp1vJIwfFiO34LAPZgq9SZW9Aw==",
             "license": "ISC",
             "optional": true,
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "@npmcli/agent": "^4.0.0",
+                "cacache": "^20.0.1",
+                "http-cache-semantics": "^4.1.1",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^5.0.0",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^1.0.0",
+                "proc-log": "^6.0.0",
+                "promise-retry": "^2.0.1",
+                "ssri": "^13.0.0"
             },
             "engines": {
-                "node": "*"
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/usocket/node_modules/minipass-fetch": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.1.tgz",
+            "integrity": "sha512-yHK8pb0iCGat0lDrs/D6RZmCdaBT64tULXjdxjSMAqoDi18Q3qKEUTHypHQZQd9+FYpIS+lkvpq6C/R6SbUeRw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "minipass": "^7.0.3",
+                "minipass-sized": "^2.0.0",
+                "minizlib": "^3.0.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            },
+            "optionalDependencies": {
+                "encoding": "^0.1.13"
+            }
+        },
+        "node_modules/usocket/node_modules/minipass-sized": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+            "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/usocket/node_modules/node-gyp": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
-            "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
+            "version": "12.2.0",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
+            "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
                 "env-paths": "^2.2.0",
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.2.3",
-                "nopt": "^5.0.0",
-                "npmlog": "^4.1.2",
-                "request": "^2.88.2",
-                "rimraf": "^3.0.2",
-                "semver": "^7.3.2",
-                "tar": "^6.0.2",
-                "which": "^2.0.2"
+                "exponential-backoff": "^3.1.1",
+                "graceful-fs": "^4.2.6",
+                "make-fetch-happen": "^15.0.0",
+                "nopt": "^9.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "tar": "^7.5.4",
+                "tinyglobby": "^0.2.12",
+                "which": "^6.0.0"
             },
             "bin": {
                 "node-gyp": "bin/node-gyp.js"
             },
             "engines": {
-                "node": ">= 10.12.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/usocket/node_modules/nopt": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-            "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+            "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
             "license": "ISC",
             "optional": true,
             "dependencies": {
-                "abbrev": "1"
+                "abbrev": "^4.0.0"
             },
             "bin": {
                 "nopt": "bin/nopt.js"
             },
             "engines": {
-                "node": ">=6"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/usocket/node_modules/npmlog": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-            "deprecated": "This package is no longer supported.",
-            "license": "ISC",
+        "node_modules/usocket/node_modules/path-scurry": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "license": "BlueOak-1.0.0",
             "optional": true,
             "dependencies": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-            }
-        },
-        "node_modules/usocket/node_modules/readable-stream": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/usocket/node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "glob": "^7.1.3"
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
             },
-            "bin": {
-                "rimraf": "bin.js"
+            "engines": {
+                "node": "20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/usocket/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "license": "MIT",
-            "optional": true
+        "node_modules/usocket/node_modules/proc-log": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "license": "ISC",
+            "optional": true,
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
         },
         "node_modules/usocket/node_modules/semver": {
             "version": "7.7.4",
@@ -20351,49 +20207,59 @@
                 "node": ">=10"
             }
         },
-        "node_modules/usocket/node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+        "node_modules/usocket/node_modules/ssri": {
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+            "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
             "license": "ISC",
-            "optional": true
-        },
-        "node_modules/usocket/node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "license": "MIT",
             "optional": true,
             "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/usocket/node_modules/string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "minipass": "^7.0.3"
             },
             "engines": {
-                "node": ">=0.10.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/usocket/node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-            "license": "MIT",
+        "node_modules/usocket/node_modules/unique-filename": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-5.0.0.tgz",
+            "integrity": "sha512-2RaJTAvAb4owyjllTfXzFClJ7WsGxlykkPvCr9pA//LD9goVq+m4PPAeBgNodGZ7nSrntT/auWpJ6Y5IFXcfjg==",
+            "license": "ISC",
             "optional": true,
             "dependencies": {
-                "ansi-regex": "^2.0.0"
+                "unique-slug": "^6.0.0"
             },
             "engines": {
-                "node": ">=0.10.0"
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/usocket/node_modules/unique-slug": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-6.0.0.tgz",
+            "integrity": "sha512-4Lup7Ezn8W3d52/xBhZBVdx323ckxa7DEvd9kPQHppTkLoJXw6ltrBCyj5pnrxj0qKDxYMJ56CoxNuFCscdTiw==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "imurmurhash": "^0.1.4"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/usocket/node_modules/which": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "isexe": "^4.0.0"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/utf8-byte-length": {
@@ -20409,17 +20275,6 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "devOptional": true,
             "license": "MIT"
-        },
-        "node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "license": "MIT",
-            "optional": true,
-            "bin": {
-                "uuid": "bin/uuid"
-            }
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
@@ -20662,15 +20517,15 @@
             }
         },
         "node_modules/wait-on": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.3.tgz",
-            "integrity": "sha512-13zBnyYvFDW1rBvWiJ6Av3ymAaq8EDQuvxZnPIw3g04UqGi4TyoIJABmfJ6zrvKo9yeFQExNkOk7idQbDJcuKA==",
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.4.tgz",
+            "integrity": "sha512-k8qrgfwrPVJXTeFY8tl6BxVHiclK11u72DVKhpybHfUL/K6KM4bdyK9EhIVYGytB5MJe/3lq4Tf0hrjM+pvJZQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "axios": "^1.13.2",
-                "joi": "^18.0.1",
-                "lodash": "^4.17.21",
+                "axios": "^1.13.5",
+                "joi": "^18.0.2",
+                "lodash": "^4.17.23",
                 "minimist": "^1.2.8",
                 "rxjs": "^7.8.2"
             },
@@ -20834,26 +20689,26 @@
             }
         },
         "node_modules/web-worker": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
-            "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
+            "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==",
             "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/webdriver": {
-            "version": "9.23.3",
-            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.23.3.tgz",
-            "integrity": "sha512-8FdXOhzkxqDI6F1dyIsQONhKLDZ9HPSEwNBnH3bD1cHnj/6nVvyYrUtDPo/+J324BuwOa1IVTH3m8mb3B2hTlA==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.24.0.tgz",
+            "integrity": "sha512-2R31Ey83NzMsafkl4hdFq6GlIBvOODQMkueLjeRqYAITu3QCYiq9oqBdnWA6CdePuV4dbKlYsKRX0mwMiPclDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^20.1.0",
                 "@types/ws": "^8.5.3",
-                "@wdio/config": "9.23.3",
+                "@wdio/config": "9.24.0",
                 "@wdio/logger": "9.18.0",
-                "@wdio/protocols": "9.23.3",
-                "@wdio/types": "9.23.3",
-                "@wdio/utils": "9.23.3",
+                "@wdio/protocols": "9.24.0",
+                "@wdio/types": "9.24.0",
+                "@wdio/utils": "9.24.0",
                 "deepmerge-ts": "^7.0.3",
                 "https-proxy-agent": "^7.0.6",
                 "undici": "^6.21.3",
@@ -20874,20 +20729,20 @@
             }
         },
         "node_modules/webdriverio": {
-            "version": "9.23.3",
-            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.23.3.tgz",
-            "integrity": "sha512-1dhMsBx/GLHJsDLhg/xuEQ48JZPrbldz7qdFT+MXQZADj9CJ4bJywWtVBME648MmVMfgDvLc5g2ThGIOupSLvQ==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.24.0.tgz",
+            "integrity": "sha512-LTJt6Z/iDM0ne/4ytd3BykoPv9CuJ+CAILOzlwFeMGn4Mj02i4Bk2Rg9o/jeJ89f52hnv4OPmNjD0e8nzWAy5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^20.11.30",
                 "@types/sinonjs__fake-timers": "^8.1.5",
-                "@wdio/config": "9.23.3",
+                "@wdio/config": "9.24.0",
                 "@wdio/logger": "9.18.0",
-                "@wdio/protocols": "9.23.3",
+                "@wdio/protocols": "9.24.0",
                 "@wdio/repl": "9.16.2",
-                "@wdio/types": "9.23.3",
-                "@wdio/utils": "9.23.3",
+                "@wdio/types": "9.24.0",
+                "@wdio/utils": "9.24.0",
                 "archiver": "^7.0.1",
                 "aria-query": "^5.3.0",
                 "cheerio": "^1.0.0-rc.12",
@@ -20904,7 +20759,7 @@
                 "rgb2hex": "0.2.5",
                 "serialize-error": "^12.0.0",
                 "urlpattern-polyfill": "^10.0.0",
-                "webdriver": "9.23.3"
+                "webdriver": "9.24.0"
             },
             "engines": {
                 "node": ">=18.20.0"
@@ -21228,7 +21083,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/ws": {
@@ -21264,9 +21119,9 @@
             }
         },
         "node_modules/xml2js": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+            "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
             "license": "MIT",
             "dependencies": {
                 "sax": ">=0.6.0",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,12 @@
         "**/*": "prettier --write --ignore-unknown"
     },
     "overrides": {
-        "tar": "^7.5.7"
+        "tar": "^7.5.7",
+        "dbus-next": {
+            "xml2js": "^0.6.2",
+            "usocket": {
+                "node-gyp": "^12.2.0"
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds scoped npm overrides for `dbus-next` transitive dependencies to resolve all 8 npm audit vulnerabilities (2 critical, 1 high, 5 moderate).

## Changes

All vulnerabilities trace to `dbus-next`'s transitive dependency tree:

| Override | Version | Fixes |
|---|---|---|
| `xml2js` | `^0.6.2` | Prototype pollution (moderate) |
| `node-gyp` | `^12.2.0` | Drops deprecated `request` lib → fixes `form-data` (critical), `qs` (high), `tough-cookie` (moderate) |

## Verification

- `npm audit`: **0 vulnerabilities** (was 8)
- Unit tests: **572 passed** ✅
- Coordinated tests: **784 passed** ✅