### PR TITLE
feat(hotkey): update Quick Chat default to Ctrl+Shift+Alt+Space for new installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Users have been asking for a desktop Gemini client with these features—**we de
 
 ### 🚀 Quick Chat - Spotlight for Gemini
 
-**Like macOS Spotlight, but for AI.** Press **`Ctrl+Shift+Space`** (or **`Cmd+Shift+Space`** on Mac) from anywhere—writing code, browsing, reading docs—and a floating command center appears instantly.
+**Like macOS Spotlight, but for AI.** Press **`Ctrl+Shift+Alt+Space`** (or **`Cmd+Shift+Alt+Space`** on Mac) from anywhere—writing code, browsing, reading docs—and a floating command center appears instantly.
 
 <!-- [INSERT QUICK CHAT SCREENSHOT HERE] -->
 
@@ -144,14 +144,14 @@ For full details, please read our [**Privacy Policy**](docs/PRIVACY.md) and [**S
 
 <div align="center">
 
-| Shortcut            | Action                                |
-| ------------------- | ------------------------------------- |
-| `Ctrl+Shift+Space`  | Toggle Quick Chat                     |
-| `Ctrl+Alt+H`        | **Peek and Hide** (Toggle visibility) |
-| `Ctrl+P`            | Print to PDF                          |
-| `Ctrl+=` / `Ctrl+-` | Zoom In / Out                         |
-| `Ctrl+,`            | Open Settings                         |
-| `Escape`            | Close Quick Chat                      |
+| Shortcut               | Action                                |
+| ---------------------- | ------------------------------------- |
+| `Ctrl+Shift+Alt+Space` | Toggle Quick Chat                     |
+| `Ctrl+Alt+H`           | **Peek and Hide** (Toggle visibility) |
+| `Ctrl+P`               | Print to PDF                          |
+| `Ctrl+=` / `Ctrl+-`    | Zoom In / Out                         |
+| `Ctrl+,`               | Open Settings                         |
+| `Escape`               | Close Quick Chat                      |
 
 </div>
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -263,7 +263,7 @@ IpcManager (orchestrator)
 
 **Name:** `HotkeyManager` (`src/main/managers/hotkeyManager.ts`)
 
-**Description:** Registers and manages global keyboard shortcuts that work even when the application is not focused. Supports customizable accelerators for Quick Chat (`Ctrl+Shift+Space`), Peek and Hide (`Ctrl+Alt+H`), Always On Top (`Ctrl+Shift+T`), and Settings (`Ctrl+,`). Includes special handling for Linux/Wayland via `GlobalShortcutsPortal`.
+**Description:** Registers and manages global keyboard shortcuts that work even when the application is not focused. Supports customizable accelerators for Quick Chat (`Ctrl+Shift+Alt+Space`), Peek and Hide (`Ctrl+Alt+H`), Always On Top (`Ctrl+Shift+T`), and Settings (`Ctrl+,`). Includes special handling for Linux/Wayland via `GlobalShortcutsPortal`.
 
 **Technologies:** Electron globalShortcut API, TypeScript
 

--- a/docs/E2E_TESTING_GUIDELINES.md
+++ b/docs/E2E_TESTING_GUIDELINES.md
@@ -229,7 +229,7 @@ E2E tests should NEVER simulate or mock the system under test.
 Before writing any code, write down the exact steps a user would take:
 
 ```text
-1. User presses Ctrl+Shift+Space
+1. User presses Ctrl+Shift+Alt+Space
 2. Quick Chat window opens
 3. User types "Hello Gemini"
 4. User presses Enter or clicks Submit

--- a/docs/TEST_PLAN_WAYLAND_HOTKEY_P0_P1.md
+++ b/docs/TEST_PLAN_WAYLAND_HOTKEY_P0_P1.md
@@ -40,7 +40,7 @@ This test plan addresses critical gaps in coverage for Wayland KDE global hotkey
 2. **Test environment**: Linux Wayland KDE Plasma 5.27+ (or mocked equivalent)
 3. **Hotkey IDs used**: `quickChat`, `peekAndHide` (Wayland global hotkeys); `alwaysOnTop`, `printToPdf` are application hotkeys (out of scope for Wayland global registration)
 4. **Portal method**: Only `dbus-direct` is currently active (`chromium-flag` is intentionally disabled)
-5. **Electron accelerator format**: Converted to XDG keysym format (e.g., `CommandOrControl+Shift+Space` → `CTRL+SHIFT+space`)
+5. **Electron accelerator format**: Converted to XDG keysym format (e.g., `CommandOrControl+Shift+Alt+Space` → `CTRL+SHIFT+ALT+space`)
 6. **Test data**: All mocked responses mimic real D-Bus portal behavior
 
 ---

--- a/docs/WAYLAND_MANUAL_TESTING.md
+++ b/docs/WAYLAND_MANUAL_TESTING.md
@@ -32,7 +32,7 @@ echo "KDE Version: $KDE_SESSION_VERSION"
 
 ### 3) Functional Hotkeys
 
-- [ ] **Quick Chat** — Press `Ctrl+Shift+Space`.
+- [ ] **Quick Chat** — Press `Ctrl+Shift+Alt+Space`.
     - Expected: Quick Chat window appears centered on screen.
 - [ ] **Peek and Hide** — Press `Ctrl+Alt+H`.
     - Expected: Main window hides to tray.

--- a/openspec/changes/add-text-prediction/tasks.md
+++ b/openspec/changes/add-text-prediction/tasks.md
@@ -341,7 +341,7 @@
 
 - [x] 6.8 Verify text prediction displays in Quick Chat
     - **Precondition:** Text prediction enabled, model ready
-    - Open Quick Chat (Ctrl+Shift+Space)
+    - Open Quick Chat (Ctrl+Shift+Alt+Space)
     - Type partial text and wait 300ms+ for prediction
     - **Acceptance:**
         - Ghost text (semi-transparent prediction) appears after cursor

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -62,7 +62,7 @@ Gemini Desktop is a native desktop wrapper for Google Gemini that provides enhan
 ## Domain Context
 
 - **Gemini Web App:** The app embeds `https://gemini.google.com/app` in an iframe after stripping `X-Frame-Options` headers
-- **Quick Chat:** Spotlight-style floating window activated by global hotkey (`Ctrl+Shift+Space`) for quick prompts
+- **Quick Chat:** Spotlight-style floating window activated by global hotkey (`Ctrl+Shift+Alt+Space`) for quick prompts
 - **Peek and Hide:** Instantly hide app to system tray via hotkey (`Ctrl+Alt+H`)
 - **Session Persistence:** Google auth sessions stored in Chromium's encrypted cookie storage via `persist:gemini` partition
 

--- a/src/shared/types/hotkeys.ts
+++ b/src/shared/types/hotkeys.ts
@@ -122,8 +122,8 @@ export const DEFAULT_ACCELERATORS: HotkeyAccelerators = {
     // Ctrl+Alt+H = Peek and Hide window
     // Note: Ctrl+Alt+E was not conflicting but H is more intuitive
     peekAndHide: 'CommandOrControl+Alt+H',
-    // Ctrl+Shift+Space = Quick Chat toggle
-    quickChat: 'CommandOrControl+Shift+Space',
+    // Ctrl+Shift+Alt+Space = Quick Chat toggle
+    quickChat: 'CommandOrControl+Shift+Alt+Space',
     // Ctrl+Shift+P = Print to PDF
     printToPdf: 'CommandOrControl+Shift+P',
 };

--- a/tests/e2e/helpers/hotkeyHelpers.ts
+++ b/tests/e2e/helpers/hotkeyHelpers.ts
@@ -327,7 +327,7 @@ export async function checkGlobalShortcutRegistration(): Promise<GlobalShortcutR
         const { globalShortcut } = _electron;
         try {
             return {
-                quickChat: globalShortcut.isRegistered('CommandOrControl+Shift+Space'),
+                quickChat: globalShortcut.isRegistered('CommandOrControl+Shift+Alt+Space'),
                 peekAndHide: globalShortcut.isRegistered('CommandOrControl+Alt+H'),
                 status: 'success',
             };

--- a/tests/e2e/helpers/keyboardActions.ts
+++ b/tests/e2e/helpers/keyboardActions.ts
@@ -52,7 +52,7 @@ export const KeyboardShortcuts = {
     QUIT: 'CmdOrCtrl+Q',
 
     // Features
-    QUICK_CHAT: 'CmdOrCtrl+Shift+Space',
+    QUICK_CHAT: 'CmdOrCtrl+Shift+Alt+Space',
 } as const;
 
 // ============================================================================

--- a/tests/e2e/hotkey-registration.spec.ts
+++ b/tests/e2e/hotkey-registration.spec.ts
@@ -43,7 +43,7 @@ describe('Global Hotkey Registration', () => {
                 return {
                     // Only check GLOBAL hotkeys - these are registered via globalShortcut
                     // Application hotkeys (alwaysOnTop, printToPdf) are handled by Menu accelerators
-                    quickChat: globalShortcut.isRegistered('CommandOrControl+Shift+Space'),
+                    quickChat: globalShortcut.isRegistered('CommandOrControl+Shift+Alt+Space'),
                     peekAndHide: globalShortcut.isRegistered('CommandOrControl+Alt+H'),
                     status: 'success',
                 };

--- a/tests/e2e/hotkeys.spec.ts
+++ b/tests/e2e/hotkeys.spec.ts
@@ -33,7 +33,7 @@ describe('Global Hotkeys', () => {
     });
 
     describe('Quick Chat Hotkey', () => {
-        it('should toggle Quick Chat window visibility when pressing CommandOrControl+Shift+Space', async () => {
+        it('should toggle Quick Chat window visibility when pressing CommandOrControl+Shift+Alt+Space', async () => {
             // ENVIRONMENTAL CHECK: Verify that hotkeys can be registered in this environment
             // On some platforms/CI environments, global hotkeys may fail to register due to:
             // - Security restrictions (Windows UAC)
@@ -43,7 +43,7 @@ describe('Global Hotkeys', () => {
                 try {
                     const { globalShortcut } = _electron;
                     return {
-                        quickChat: globalShortcut.isRegistered('CommandOrControl+Shift+Space'),
+                        quickChat: globalShortcut.isRegistered('CommandOrControl+Shift+Alt+Space'),
                     };
                 } catch (error) {
                     return { quickChat: false, error: (error as Error).message };
@@ -68,8 +68,7 @@ describe('Global Hotkeys', () => {
             }
 
             // 2. ACTION: Press the Hotkey via workflow helper
-            // Simulating: Cmd/Ctrl + Shift + Space
-            await pressComplexShortcut(['primary', 'shift'], 'Space');
+            await pressComplexShortcut(['primary', 'shift', 'alt'], 'Space');
 
             // Allow time for window animation and OS handling
             await waitForWindowTransition();
@@ -80,7 +79,7 @@ describe('Global Hotkeys', () => {
             expect(isVisibleAfterOpen).toBe(true);
 
             // 4. ACTION: Press Hotkey again to close (Toggle behavior)
-            await pressComplexShortcut(['primary', 'shift'], 'Space');
+            await pressComplexShortcut(['primary', 'shift', 'alt'], 'Space');
             await waitForWindowTransition();
 
             // 5. VERIFICATION: Quick Chat should be hidden via Page Object

--- a/tests/e2e/quick-chat.spec.ts
+++ b/tests/e2e/quick-chat.spec.ts
@@ -52,7 +52,7 @@ describe('Quick Chat Feature', () => {
             // Verify the hotkey is actually registered at the OS level
             // Note: Triggering the hotkey via robotjs is flaky, so we verify registration status instead.
             // This follows E2E principles by checking ACTUAL registration state, not manipulating internals.
-            const defaultAccelerator = 'CommandOrControl+Shift+Space';
+            const defaultAccelerator = 'CommandOrControl+Shift+Alt+Space';
             const isRegistered = await isHotkeyRegistered(defaultAccelerator);
 
             E2ELogger.info('quick-chat', `Hotkey "${defaultAccelerator}" registration: ${isRegistered}`);
@@ -80,9 +80,9 @@ describe('Quick Chat Feature', () => {
 
             // Verify platform-specific display format
             if (platform === 'macos') {
-                expect(displayString).toBe('Cmd+Shift+Space');
+                expect(displayString).toBe('Cmd+Shift+Alt+Space');
             } else {
-                expect(displayString).toBe('Ctrl+Shift+Space');
+                expect(displayString).toBe('Ctrl+Shift+Alt+Space');
             }
 
             E2ELogger.info('quick-chat', `Platform: ${platform}, Display String: ${displayString}`);

--- a/tests/helpers/mocks/renderer/electronAPI.ts
+++ b/tests/helpers/mocks/renderer/electronAPI.ts
@@ -108,7 +108,7 @@ export function createMockElectronAPI(overrides: MockElectronAPIOverrides = {}):
         // Hotkey Accelerators API
         // =========================================================================
         getHotkeyAccelerators: vi.fn().mockResolvedValue({
-            quickChat: 'CommandOrControl+Shift+Space',
+            quickChat: 'CommandOrControl+Shift+Alt+Space',
             alwaysOnTop: 'CommandOrControl+Alt+T',
             printToPdf: 'CommandOrControl+Alt+P',
         }),
@@ -119,7 +119,7 @@ export function createMockElectronAPI(overrides: MockElectronAPIOverrides = {}):
                 printToPdf: true,
             },
             accelerators: {
-                quickChat: 'CommandOrControl+Shift+Space',
+                quickChat: 'CommandOrControl+Shift+Alt+Space',
                 alwaysOnTop: 'CommandOrControl+Alt+T',
                 printToPdf: 'CommandOrControl+Alt+P',
             },

--- a/tests/integration/hotkeys.integration.test.ts
+++ b/tests/integration/hotkeys.integration.test.ts
@@ -10,7 +10,7 @@ describe('Global Hotkeys Integration', () => {
         // Verify registration via Main Process
         const isRegistered = await browser.electron.execute((_electron) => {
             // Check if the 'quickChat' accelerator is registered
-            // We know the accelerator is 'CommandOrControl+Shift+Space'
+            // We know the accelerator is 'CommandOrControl+Shift+Alt+Space'
             // We can also check internal manager state
             // @ts-expect-error
             return global.hotkeyManager.isIndividualEnabled('quickChat');

--- a/tests/integration/wayland-platform-status.integration.test.ts
+++ b/tests/integration/wayland-platform-status.integration.test.ts
@@ -102,7 +102,7 @@ describe('Platform Hotkey Status IPC', () => {
             const isQuickChatRegistered = await browserWithElectron.electron.execute(() => {
                 const { globalShortcut } = require('electron');
                 // Use the default quickChat accelerator
-                return globalShortcut.isRegistered('CommandOrControl+Shift+Space');
+                return globalShortcut.isRegistered('CommandOrControl+Shift+Alt+Space');
             });
 
             // If any global hotkey is registered, globalHotkeysEnabled should be true

--- a/tests/unit/main/store.test.ts
+++ b/tests/unit/main/store.test.ts
@@ -215,7 +215,7 @@ describe('SettingsStore', () => {
             hotkeyAccelerators: {
                 alwaysOnTop: 'CommandOrControl+Alt+P',
                 peekAndHide: 'CommandOrControl+Alt+H',
-                quickChat: 'CommandOrControl+Shift+Space',
+                quickChat: 'CommandOrControl+Shift+Alt+Space',
                 printToPdf: 'CommandOrControl+Shift+P',
             },
         };
@@ -402,7 +402,7 @@ describe('SettingsStore', () => {
                     hotkeyAccelerators: {
                         alwaysOnTop: 'CommandOrControl+Shift+T', // User's custom accelerator
                         peekAndHide: 'CommandOrControl+Alt+H',
-                        quickChat: 'CommandOrControl+Shift+Space',
+                        quickChat: 'CommandOrControl+Shift+Alt+Space',
                         printToPdf: 'CommandOrControl+Alt+P', // User changed the accelerator
                     },
                 };

--- a/tests/unit/main/utils/dbusFallback.test.ts
+++ b/tests/unit/main/utils/dbusFallback.test.ts
@@ -185,7 +185,9 @@ describe('DBusFallback', () => {
 
     describe('electronAcceleratorToXdg', () => {
         it('converts CommandOrControl to CTRL', () => {
-            expect(dbusFallback.electronAcceleratorToXdg('CommandOrControl+Shift+Space')).toBe('CTRL+SHIFT+space');
+            expect(dbusFallback.electronAcceleratorToXdg('CommandOrControl+Shift+Alt+Space')).toBe(
+                'CTRL+SHIFT+ALT+space'
+            );
         });
 
         it('converts CmdOrCtrl to CTRL', () => {
@@ -227,7 +229,9 @@ describe('DBusFallback', () => {
         });
 
         it('handles the default app accelerators correctly', () => {
-            expect(dbusFallback.electronAcceleratorToXdg('CommandOrControl+Shift+Space')).toBe('CTRL+SHIFT+space');
+            expect(dbusFallback.electronAcceleratorToXdg('CommandOrControl+Shift+Alt+Space')).toBe(
+                'CTRL+SHIFT+ALT+space'
+            );
             expect(dbusFallback.electronAcceleratorToXdg('CommandOrControl+Alt+H')).toBe('CTRL+ALT+h');
             expect(dbusFallback.electronAcceleratorToXdg('CommandOrControl+Alt+P')).toBe('CTRL+ALT+p');
             expect(dbusFallback.electronAcceleratorToXdg('CommandOrControl+Shift+P')).toBe('CTRL+SHIFT+p');
@@ -333,7 +337,11 @@ describe('DBusFallback', () => {
 
     describe('registerViaDBus', () => {
         const testShortcuts = [
-            { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat toggle' },
+            {
+                id: 'quickChat' as const,
+                accelerator: 'CommandOrControl+Shift+Alt+Space',
+                description: 'Quick Chat toggle',
+            },
             { id: 'peekAndHide' as const, accelerator: 'CommandOrControl+Alt+H', description: 'Hide window' },
         ];
 
@@ -369,7 +377,7 @@ describe('DBusFallback', () => {
 
             // Check that accelerators were converted
             const quickChatTrigger = shortcutSpecs[0][1].preferred_trigger;
-            expect(quickChatTrigger.value).toBe('CTRL+SHIFT+space');
+            expect(quickChatTrigger.value).toBe('CTRL+SHIFT+ALT+space');
 
             const peekAndHideTrigger = shortcutSpecs[1][1].preferred_trigger;
             expect(peekAndHideTrigger.value).toBe('CTRL+ALT+h');
@@ -652,7 +660,11 @@ describe('DBusFallback', () => {
     describe('destroySession', () => {
         it('disconnects D-Bus connection when session exists', async () => {
             await dbusFallback.registerViaDBus([
-                { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+                {
+                    id: 'quickChat' as const,
+                    accelerator: 'CommandOrControl+Shift+Alt+Space',
+                    description: 'Quick Chat',
+                },
             ]);
 
             await dbusFallback.destroySession();
@@ -662,7 +674,11 @@ describe('DBusFallback', () => {
 
         it('removes bus-level message handler on destroy', async () => {
             await dbusFallback.registerViaDBus([
-                { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+                {
+                    id: 'quickChat' as const,
+                    accelerator: 'CommandOrControl+Shift+Alt+Space',
+                    description: 'Quick Chat',
+                },
             ]);
 
             await dbusFallback.destroySession();
@@ -676,7 +692,11 @@ describe('DBusFallback', () => {
 
         it('cleans up session state (allows new registration)', async () => {
             await dbusFallback.registerViaDBus([
-                { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+                {
+                    id: 'quickChat' as const,
+                    accelerator: 'CommandOrControl+Shift+Alt+Space',
+                    description: 'Quick Chat',
+                },
             ]);
 
             await dbusFallback.destroySession();
@@ -691,7 +711,11 @@ describe('DBusFallback', () => {
 
         it('handles disconnect errors gracefully', async () => {
             await dbusFallback.registerViaDBus([
-                { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+                {
+                    id: 'quickChat' as const,
+                    accelerator: 'CommandOrControl+Shift+Alt+Space',
+                    description: 'Quick Chat',
+                },
             ]);
 
             mockDisconnect.mockImplementation(() => {
@@ -720,7 +744,11 @@ describe('DBusFallback', () => {
             mockGetProxyObject.mockRejectedValue(new Error('org.freedesktop.DBus.Error.NameHasNoOwner'));
 
             const results = await dbusFallback.registerViaDBus([
-                { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+                {
+                    id: 'quickChat' as const,
+                    accelerator: 'CommandOrControl+Shift+Alt+Space',
+                    description: 'Quick Chat',
+                },
             ]);
 
             expect(results[0].success).toBe(false);
@@ -731,7 +759,11 @@ describe('DBusFallback', () => {
             mockCreateSession.mockRejectedValue(new Error('org.freedesktop.DBus.Error.Timeout'));
 
             const results = await dbusFallback.registerViaDBus([
-                { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+                {
+                    id: 'quickChat' as const,
+                    accelerator: 'CommandOrControl+Shift+Alt+Space',
+                    description: 'Quick Chat',
+                },
             ]);
 
             expect(results[0].success).toBe(false);
@@ -742,7 +774,11 @@ describe('DBusFallback', () => {
             mockCreateSession.mockRejectedValue(new Error('org.freedesktop.DBus.Error.AccessDenied'));
 
             const results = await dbusFallback.registerViaDBus([
-                { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+                {
+                    id: 'quickChat' as const,
+                    accelerator: 'CommandOrControl+Shift+Alt+Space',
+                    description: 'Quick Chat',
+                },
             ]);
 
             expect(results[0].success).toBe(false);
@@ -753,7 +789,11 @@ describe('DBusFallback', () => {
             mockBindShortcuts.mockRejectedValue(new Error('org.freedesktop.DBus.Error.NoReply'));
 
             const results = await dbusFallback.registerViaDBus([
-                { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+                {
+                    id: 'quickChat' as const,
+                    accelerator: 'CommandOrControl+Shift+Alt+Space',
+                    description: 'Quick Chat',
+                },
             ]);
 
             expect(results[0].success).toBe(false);
@@ -764,7 +804,11 @@ describe('DBusFallback', () => {
             mockGetProxyObject.mockRejectedValue(new Error('org.freedesktop.DBus.Error.ServiceUnknown'));
 
             const results = await dbusFallback.registerViaDBus([
-                { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+                {
+                    id: 'quickChat' as const,
+                    accelerator: 'CommandOrControl+Shift+Alt+Space',
+                    description: 'Quick Chat',
+                },
             ]);
 
             expect(results[0].success).toBe(false);
@@ -780,7 +824,11 @@ describe('DBusFallback', () => {
             });
 
             const results = await dbusFallback.registerViaDBus([
-                { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+                {
+                    id: 'quickChat' as const,
+                    accelerator: 'CommandOrControl+Shift+Alt+Space',
+                    description: 'Quick Chat',
+                },
             ]);
 
             expect(results[0].success).toBe(false);
@@ -794,7 +842,7 @@ describe('DBusFallback', () => {
                 dbusFallback.registerViaDBus([
                     {
                         id: 'quickChat' as const,
-                        accelerator: 'CommandOrControl+Shift+Space',
+                        accelerator: 'CommandOrControl+Shift+Alt+Space',
                         description: 'Quick Chat',
                     },
                 ])
@@ -809,7 +857,11 @@ describe('DBusFallback', () => {
 
         it('never throws uncaught exceptions to caller from destroySession', async () => {
             await dbusFallback.registerViaDBus([
-                { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+                {
+                    id: 'quickChat' as const,
+                    accelerator: 'CommandOrControl+Shift+Alt+Space',
+                    description: 'Quick Chat',
+                },
             ]);
             mockDisconnect.mockImplementation(() => {
                 throw new Error('Crash during disconnect');
@@ -826,7 +878,11 @@ describe('DBusFallback', () => {
     describe('Session Lifecycle', () => {
         it('creates new session on repeated registerViaDBus calls (destroying previous)', async () => {
             await dbusFallback.registerViaDBus([
-                { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+                {
+                    id: 'quickChat' as const,
+                    accelerator: 'CommandOrControl+Shift+Alt+Space',
+                    description: 'Quick Chat',
+                },
             ]);
             await dbusFallback.registerViaDBus([
                 { id: 'peekAndHide' as const, accelerator: 'CommandOrControl+Alt+H', description: 'Peek and Hide' },
@@ -861,7 +917,11 @@ describe('DBusFallback', () => {
             );
 
             const testShortcuts = [
-                { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+                {
+                    id: 'quickChat' as const,
+                    accelerator: 'CommandOrControl+Shift+Alt+Space',
+                    description: 'Quick Chat',
+                },
                 { id: 'peekAndHide' as const, accelerator: 'CommandOrControl+Alt+H', description: 'Peek and Hide' },
             ];
 
@@ -888,7 +948,11 @@ describe('DBusFallback', () => {
             mockBindShortcuts.mockRejectedValue(new Error('org.freedesktop.DBus.Error.NotConnected'));
 
             const testShortcuts = [
-                { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+                {
+                    id: 'quickChat' as const,
+                    accelerator: 'CommandOrControl+Shift+Alt+Space',
+                    description: 'Quick Chat',
+                },
                 { id: 'peekAndHide' as const, accelerator: 'CommandOrControl+Alt+H', description: 'Peek and Hide' },
             ];
 
@@ -905,7 +969,11 @@ describe('DBusFallback', () => {
 
         describe('P1-1: User Dismissal vs System Error', () => {
             const testShortcuts = [
-                { id: 'quickChat' as const, accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+                {
+                    id: 'quickChat' as const,
+                    accelerator: 'CommandOrControl+Shift+Alt+Space',
+                    description: 'Quick Chat',
+                },
             ];
 
             it('P1-1a: should handle user dismissal (code=1) as non-success', async () => {

--- a/tests/unit/shared/hotkeys.test.ts
+++ b/tests/unit/shared/hotkeys.test.ts
@@ -274,7 +274,7 @@ describe('Hotkey Types', () => {
 
         it('should accept custom accelerator for printToPdf', () => {
             const settings: HotkeySettings = {
-                quickChat: { enabled: true, accelerator: 'CommandOrControl+Shift+Space' },
+                quickChat: { enabled: true, accelerator: 'CommandOrControl+Shift+Alt+Space' },
                 peekAndHide: { enabled: true, accelerator: 'CommandOrControl+Alt+E' },
                 alwaysOnTop: { enabled: true, accelerator: 'CommandOrControl+Shift+T' },
                 printToPdf: { enabled: true, accelerator: 'CommandOrControl+Alt+P' },


### PR DESCRIPTION
## Summary

- Updates the Quick Chat hotkey default from `Ctrl+Shift+Space` to `Ctrl+Shift+Alt+Space`
- **New installs only** — existing users keep their current hotkey setting (no forced migration)
- Updates all tests (unit, integration, e2e) and documentation

## Changes

- `DEFAULT_ACCELERATORS.quickChat` in `src/shared/types/hotkeys.ts`
- E2E and integration test files (7 files)
- Unit test fixtures (1 file)
- Documentation (7 files: README, ARCHITECTURE, test plans, etc.)

## Behavior

| Scenario | Result |
|----------|--------|
| New install | Gets new default `Ctrl+Shift+Alt+Space` |
| Existing user with old default `Ctrl+Shift+Space` | Keeps their setting |
| Existing user with custom hotkey | Keeps their setting |

The `?? DEFAULT_ACCELERATORS.quickChat` fallback in `_getAccelerators()` naturally handles this — new installs have no stored value and get the new default; existing installs have a stored value and keep it.