### PR TITLE
docs(hotkey): clarify Peek and Hide toggles between hide/restore

### DIFF
--- a/src/main/managers/hotkeyManager.ts
+++ b/src/main/managers/hotkeyManager.ts
@@ -213,7 +213,7 @@ export default class HotkeyManager {
         // Define shortcut actions
         // Each shortcut maps an id to an action callback
         this.shortcutActions = [
-            // GLOBAL: Peek and Hide needs to work even when app is hidden/unfocused to quickly hide it system-wide
+            // GLOBAL: Peek and Hide toggles between hiding to system tray and restoring the window
             {
                 id: 'peekAndHide',
                 action: () => {

--- a/src/renderer/components/options/IndividualHotkeyToggles.tsx
+++ b/src/renderer/components/options/IndividualHotkeyToggles.tsx
@@ -6,7 +6,7 @@
  *
  * ## Hotkeys
  * - **Always on Top**: Toggle window always-on-top
- * - **Peek and Hide**: Minimize window
+ * - **Peek and Hide**: Toggle hide to/restore from system tray
  * - **Quick Chat**: Open quick chat overlay
  *
  * @module IndividualHotkeyToggles
@@ -45,7 +45,7 @@ const HOTKEY_CONFIGS: HotkeyConfig[] = [
     {
         id: 'peekAndHide',
         label: 'Peek and Hide',
-        description: 'Quickly minimize to system tray',
+        description: 'Toggle hide to/restore from system tray',
     },
     {
         id: 'quickChat',


### PR DESCRIPTION
## Summary
- Update Peek and Hide descriptions to clarify it toggles between hiding to system tray and restoring the window
- The options menu previously only said "minimize" which was incomplete

## Changes
- `IndividualHotkeyToggles.tsx`: Updated UI description from "Quickly minimize to system tray" to "Toggle hide to/restore from system tray"
- `hotkeyManager.ts`: Updated comment to reflect toggle behavior