### PR TITLE
fix: restrict push trigger to main to prevent duplicate CI runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ name: Test
 # =============================================================================
 on:
     push:
-        # Run on all branches
+        branches: [main]
     pull_request:
         branches: [main]
     # Allow manual triggering from Actions tab


### PR DESCRIPTION
## Problem

Every PR runs each test group **twice** — once for the `push` event and once for the `pull_request` event:


This happens because the `push` trigger in `test.yml` had no branch filter, so it fires on all branches including PR feature branches.

The concurrency group (`${{ github.workflow }}-${{ github.ref }}`) doesn't deduplicate them because `github.ref` resolves differently for each event type (`refs/heads/branch-name` for push vs `refs/pull/123/merge` for pull_request).

## Fix

Restrict `push` to only `branches: [main]` so it only runs for post-merge verification. PRs are fully covered by the `pull_request` trigger.

Feature branches without a PR can still be tested manually:
```bash
gh workflow run test.yml --ref <branch-name>
```

## Impact

- **Halves CI usage on every PR** (removes ~50% of redundant workflow runs)
- No change to test coverage — all PRs still run the full suite via `pull_request`
- Post-merge verification on `main` still works via `push`
- Manual testing via `workflow_dispatch` still works on any branch