### PR TITLE
feat(test): auto-configure headless ARM WDIO execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,16 @@ The project uses **npm** for package management and **Vitest** + **WebdriverIO**
 - `npm run test:watch` - Run unit tests in watch mode
 - `npm run test:electron` - Run electron-specific unit tests
 - `npm run test:coordinated` - Run coordinated multi-window tests
+- `npm run test:integration` - Run WDIO integration tests
 - `npm run test:e2e` - Run E2E tests sequentially
+- `npm run test:headless:auto` - Coordinated + integration + E2E with headless ARM auto-detection
 - `npm run test:all` - Run all test suites
+
+**Headless ARM note (AI agents):**
+
+- On Linux ARM64 hosts, WDIO now auto-detects headless mode, provisions ARM Chromedriver, and sets `CHROMEDRIVER_PATH` automatically.
+- Use `npm run test:headless:auto` for one-command validation in headless ARM environments.
+- Optional overrides: `CHROMEDRIVER_PATH=/abs/path/to/chromedriver` and `GEMINI_DESKTOP_CACHE_DIR=/path/to/cache`.
 
 **Running a Single Test:**
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,26 @@ npm run test:all
 
 # Run only E2E tests
 npm run test:e2e
+
+# Auto-detect headless ARM/Linux for coordinated + integration + E2E
+npm run test:headless:auto
 ```
+
+### Headless ARM Linux Auto-Mode
+
+When running on a headless Linux ARM64 machine, WDIO now auto-configures itself:
+
+- Detects `linux + arm64` and enables CI/Xvfb-compatible behavior for WDIO.
+- Downloads and caches ARM Chromedriver matching installed Electron.
+- Exports `CHROMEDRIVER_PATH` automatically so WDIO uses the ARM binary.
+- Auto-sets `SKIP_BUILD=true` if `node-llama-cpp` is unavailable but `dist-electron` already exists.
+
+Manual overrides are available if needed:
+
+- `CHROMEDRIVER_PATH=/abs/path/to/chromedriver` to pin a custom driver.
+- `GEMINI_DESKTOP_CACHE_DIR=/abs/cache/dir` to customize driver cache location.
+
+See `docs/HEADLESS_ARM_TESTING.md` for details.
 
 We believe that a robust test suite is key to maintaining a high-quality experience.
 

--- a/config/wdio/wdio.base.conf.js
+++ b/config/wdio/wdio.base.conf.js
@@ -9,9 +9,12 @@ import path from 'path';
 import { promises as fs } from 'fs';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
-import { getAppArgs, linuxServiceConfig, killOrphanElectronProcesses } from './electron-args.js';
+import armEnv from '../../scripts/wdio-arm-env.cjs';
+import { getAppArgs, getLinuxServiceConfig, killOrphanElectronProcesses } from './electron-args.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const projectRoot = path.resolve(__dirname, '../..');
+armEnv.applyArmWdioEnvironment(projectRoot);
 const SPEC_FILE_RETRIES = Number(process.env.WDIO_SPEC_FILE_RETRIES ?? 2);
 const SPEC_FILE_RETRY_DELAY_SECONDS = Number(process.env.WDIO_SPEC_FILE_RETRY_DELAY_SECONDS ?? 5);
 const TEST_RETRIES = Number(process.env.WDIO_TEST_RETRIES ?? 2);
@@ -27,7 +30,7 @@ export const baseConfig = {
             {
                 appEntryPoint: electronMainPath,
                 appArgs: getAppArgs('--test-auto-update', '--e2e-disable-auto-submit'),
-                ...linuxServiceConfig,
+                ...getLinuxServiceConfig(),
             },
         ],
     ],
@@ -56,7 +59,7 @@ export const baseConfig = {
 
     // Build the frontend and Electron backend before tests
     onPrepare: () => {
-        if (process.env.SKIP_BUILD) {
+        if (armEnv.isTruthyEnv(process.env.SKIP_BUILD)) {
             console.log('Skipping build (SKIP_BUILD is set)...');
             return;
         }

--- a/config/wdio/wdio.conf.js
+++ b/config/wdio/wdio.conf.js
@@ -13,9 +13,12 @@ import path from 'path';
 import { promises as fs } from 'fs';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
-import { getAppArgs, linuxServiceConfig, killOrphanElectronProcesses } from './electron-args.js';
+import armEnv from '../../scripts/wdio-arm-env.cjs';
+import { getAppArgs, getLinuxServiceConfig, killOrphanElectronProcesses } from './electron-args.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const projectRoot = path.resolve(__dirname, '../..');
+armEnv.applyArmWdioEnvironment(projectRoot);
 const SPEC_FILE_RETRIES = Number(process.env.WDIO_SPEC_FILE_RETRIES ?? 2);
 const SPEC_FILE_RETRY_DELAY_SECONDS = Number(process.env.WDIO_SPEC_FILE_RETRY_DELAY_SECONDS ?? 5);
 const TEST_RETRIES = Number(process.env.WDIO_TEST_RETRIES ?? 2);
@@ -143,7 +146,7 @@ export const config = {
             {
                 appEntryPoint: electronMainPath,
                 appArgs: getAppArgs('--test-auto-update', '--e2e-disable-auto-submit'),
-                ...linuxServiceConfig,
+                ...getLinuxServiceConfig(),
             },
         ],
     ],
@@ -172,7 +175,7 @@ export const config = {
 
     // Build the frontend and Electron backend before tests
     onPrepare: () => {
-        if (process.env.SKIP_BUILD) {
+        if (armEnv.isTruthyEnv(process.env.SKIP_BUILD)) {
             console.log('Skipping build (SKIP_BUILD is set)...');
             return;
         }

--- a/config/wdio/wdio.release.conf.js
+++ b/config/wdio/wdio.release.conf.js
@@ -15,9 +15,12 @@
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
-import { getAppArgs, linuxServiceConfig, killOrphanElectronProcesses } from './electron-args.js';
+import armEnv from '../../scripts/wdio-arm-env.cjs';
+import { getAppArgs, getLinuxServiceConfig, killOrphanElectronProcesses } from './electron-args.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const projectRoot = path.resolve(__dirname, '../..');
+armEnv.applyArmWdioEnvironment(projectRoot);
 const SPEC_FILE_RETRIES = Number(process.env.WDIO_SPEC_FILE_RETRIES ?? 2);
 const SPEC_FILE_RETRY_DELAY_SECONDS = Number(process.env.WDIO_SPEC_FILE_RETRY_DELAY_SECONDS ?? 5);
 const TEST_RETRIES = Number(process.env.WDIO_TEST_RETRIES ?? 2);
@@ -115,7 +118,7 @@ export const config = {
             {
                 appBinaryPath: getReleaseBinaryPath(),
                 appArgs: getAppArgs('--test-auto-update'),
-                ...linuxServiceConfig,
+                ...getLinuxServiceConfig(),
             },
         ],
     ],

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -92,14 +92,16 @@ npm run electron:dev
 
 ### Available Scripts
 
-| Script                   | Description             |
-| ------------------------ | ----------------------- |
-| `npm run electron:dev`   | Start development mode  |
-| `npm run electron:build` | Build for production    |
-| `npm run test`           | Run React unit tests    |
-| `npm run test:electron`  | Run Electron unit tests |
-| `npm run test:e2e`       | Run E2E tests           |
-| `npm run test:all`       | Run all tests           |
+| Script                       | Description                                          |
+| ---------------------------- | ---------------------------------------------------- |
+| `npm run electron:dev`       | Start development mode                               |
+| `npm run electron:build`     | Build for production                                 |
+| `npm run test`               | Run React unit tests                                 |
+| `npm run test:electron`      | Run Electron unit tests                              |
+| `npm run test:e2e`           | Run E2E tests                                        |
+| `npm run test:integration`   | Run WDIO integration tests                           |
+| `npm run test:headless:auto` | Auto-detect headless ARM coordinated+integration+E2E |
+| `npm run test:all`           | Run all tests                                        |
 
 ---
 
@@ -155,6 +157,9 @@ npm run test:electron
 
 # E2E tests (requires built app)
 npm run test:e2e
+
+# Headless ARM Linux auto-mode (coordinated + integration + E2E)
+npm run test:headless:auto
 ```
 
 ### Writing Tests

--- a/docs/E2E_TESTING_GUIDELINES.md
+++ b/docs/E2E_TESTING_GUIDELINES.md
@@ -427,6 +427,16 @@ npm run test:e2e        # Runs all specs in the sequential runner
 npm run test:e2e:all    # Runs all specs including lifecycle tests
 ```
 
+### Headless ARM Linux (AI Agent Path)
+
+For Linux ARM64 headless environments, use the auto-mode script:
+
+```bash
+npm run test:headless:auto
+```
+
+This path automatically configures CI/Xvfb-compatible execution and ARM Chromedriver resolution.
+
 ### Running Integration Tests (Single Spec)
 
 Integration tests support the `--spec` flag correctly:

--- a/docs/HEADLESS_ARM_TESTING.md
+++ b/docs/HEADLESS_ARM_TESTING.md
@@ -1,0 +1,57 @@
+# Headless ARM Linux Testing
+
+This project now supports automatic WDIO test setup on headless Linux ARM64 hosts.
+
+## One command
+
+Run the full coordinated + integration + E2E flow:
+
+```bash
+npm run test:headless:auto
+```
+
+## What auto-detection does
+
+When `process.platform === 'linux'` and `process.arch === 'arm64'`, the WDIO startup path automatically:
+
+1. Sets CI-style behavior for headless execution if no display is available.
+2. Resolves installed Electron version from `node_modules/electron/package.json`.
+3. Downloads matching ARM Chromedriver from Electron releases.
+4. Caches Chromedriver locally and exports `CHROMEDRIVER_PATH`.
+5. Enables `SKIP_BUILD=true` when `node-llama-cpp` is missing but prebuilt Electron artifacts exist.
+
+This is wired into WDIO config entrypoints, so normal commands also benefit:
+
+- `npm run test:integration`
+- `npm run test:e2e:spec`
+- `npm run test:e2e`
+
+## Cache location
+
+Default cache path:
+
+```text
+~/.cache/gemini-desktop/chromedriver/
+```
+
+Override cache root:
+
+```bash
+export GEMINI_DESKTOP_CACHE_DIR=/path/to/cache
+```
+
+## Optional overrides
+
+Pin your own Chromedriver binary:
+
+```bash
+export CHROMEDRIVER_PATH=/abs/path/to/chromedriver
+```
+
+If `CHROMEDRIVER_PATH` is set, auto-download is skipped.
+
+## Notes
+
+- The first run downloads Chromedriver. Later runs reuse cache.
+- WDIO still may retry flaky E2E specs in CI-like headless environments; this is expected.
+- Coordinated tests are Vitest-based and do not require Chromedriver.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "test:e2e:lifecycle": "wdio run config/wdio/wdio.lifecycle.conf.js",
         "test:e2e:release": "wdio run config/wdio/wdio.release.conf.js",
         "test:e2e:all": "npm run test:e2e && npm run test:e2e:lifecycle",
+        "test:headless:auto": "npm run test:coordinated && npm run test:integration && npm run test:e2e",
         "test:all": "npm run test && npm run test:electron && npm run test:coordinated && npm run test:integration && npm run test:e2e:all",
         "docs": "typedoc --out docs src"
     },

--- a/scripts/wdio-arm-env.cjs
+++ b/scripts/wdio-arm-env.cjs
@@ -1,0 +1,157 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+function isLinuxArm64() {
+    return process.platform === 'linux' && process.arch === 'arm64';
+}
+
+function runOrThrow(command, args, options = {}) {
+    const result = spawnSync(command, args, { stdio: 'inherit', ...options });
+    if (result.status !== 0) {
+        throw new Error(`Command failed: ${command} ${args.join(' ')}`);
+    }
+}
+
+function isTruthyEnv(value) {
+    return /^(1|true|yes|on)$/i.test(String(value ?? ''));
+}
+
+function hasCommand(command) {
+    const result = spawnSync(command, ['--version'], { stdio: 'ignore' });
+    return result.status === 0;
+}
+
+function findChromedriverBinary(rootDir) {
+    const stack = [rootDir];
+
+    while (stack.length > 0) {
+        const current = stack.pop();
+        const entries = fs.readdirSync(current, { withFileTypes: true });
+
+        for (const entry of entries) {
+            const fullPath = path.join(current, entry.name);
+
+            if (entry.isDirectory()) {
+                stack.push(fullPath);
+                continue;
+            }
+
+            if (entry.isFile() && entry.name === 'chromedriver') {
+                return fullPath;
+            }
+        }
+    }
+
+    return null;
+}
+
+function resolveElectronVersion(projectRoot) {
+    const electronPackageJsonPath = path.join(projectRoot, 'node_modules', 'electron', 'package.json');
+
+    if (!fs.existsSync(electronPackageJsonPath)) {
+        throw new Error('Electron is not installed. Run npm install first.');
+    }
+
+    const electronPackage = JSON.parse(fs.readFileSync(electronPackageJsonPath, 'utf8'));
+    return electronPackage.version;
+}
+
+function resolveCacheRoot() {
+    if (process.env.GEMINI_DESKTOP_CACHE_DIR) {
+        return process.env.GEMINI_DESKTOP_CACHE_DIR;
+    }
+
+    if (process.env.XDG_CACHE_HOME) {
+        return path.join(process.env.XDG_CACHE_HOME, 'gemini-desktop');
+    }
+
+    return path.join(os.homedir(), '.cache', 'gemini-desktop');
+}
+
+function resolveArmChromedriver(projectRoot) {
+    const electronVersion = resolveElectronVersion(projectRoot);
+    const cacheDir = path.join(resolveCacheRoot(), 'chromedriver', `electron-v${electronVersion}-linux-arm64`);
+    const zipPath = path.join(cacheDir, `chromedriver-v${electronVersion}-linux-arm64.zip`);
+    const extractDir = path.join(cacheDir, 'extract');
+
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.mkdirSync(extractDir, { recursive: true });
+
+    const cachedBinary = findChromedriverBinary(extractDir);
+    if (cachedBinary && fs.existsSync(cachedBinary)) {
+        fs.chmodSync(cachedBinary, 0o755);
+        return cachedBinary;
+    }
+
+    const downloadUrl = `https://github.com/electron/electron/releases/download/v${electronVersion}/chromedriver-v${electronVersion}-linux-arm64.zip`;
+    console.log(`[wdio-arm-env] Downloading ARM64 Chromedriver for Electron v${electronVersion}`);
+    if (hasCommand('curl')) {
+        runOrThrow('curl', ['-fL', downloadUrl, '-o', zipPath]);
+    } else if (hasCommand('wget')) {
+        runOrThrow('wget', ['-O', zipPath, downloadUrl]);
+    } else {
+        throw new Error('Neither curl nor wget is available. Install one to download ARM Chromedriver.');
+    }
+
+    console.log('[wdio-arm-env] Extracting Chromedriver archive');
+    if (hasCommand('unzip')) {
+        runOrThrow('unzip', ['-o', zipPath, '-d', extractDir]);
+    } else if (hasCommand('python3')) {
+        const pythonScript = [
+            'import pathlib, zipfile',
+            `zip_path = pathlib.Path(${JSON.stringify(zipPath)})`,
+            `extract_dir = pathlib.Path(${JSON.stringify(extractDir)})`,
+            'extract_dir.mkdir(parents=True, exist_ok=True)',
+            "with zipfile.ZipFile(zip_path, 'r') as zf:",
+            '    zf.extractall(extract_dir)',
+        ].join('\n');
+        runOrThrow('python3', ['-c', pythonScript]);
+    } else {
+        throw new Error('Neither unzip nor python3 is available. Install one to extract ARM Chromedriver archive.');
+    }
+
+    const extractedBinary = findChromedriverBinary(extractDir);
+    if (!extractedBinary) {
+        throw new Error(`Chromedriver binary not found after extraction in ${extractDir}`);
+    }
+
+    fs.chmodSync(extractedBinary, 0o755);
+    return extractedBinary;
+}
+
+function applyArmWdioEnvironment(projectRoot) {
+    if (!isLinuxArm64()) {
+        return;
+    }
+
+    if (!process.env.CI && !process.env.DISPLAY) {
+        process.env.CI = 'true';
+        console.log('[wdio-arm-env] Headless Linux ARM detected, forcing CI=true for WDIO autoXvfb');
+    }
+
+    const skipBuildWasExplicitlySet = typeof process.env.SKIP_BUILD === 'string' && process.env.SKIP_BUILD.length > 0;
+
+    if (!skipBuildWasExplicitlySet) {
+        const hasOptionalLlamaModule = fs.existsSync(path.join(projectRoot, 'node_modules', 'node-llama-cpp'));
+        const hasCompiledElectron = fs.existsSync(path.join(projectRoot, 'dist-electron', 'main', 'main.cjs'));
+
+        if (!hasOptionalLlamaModule && hasCompiledElectron) {
+            process.env.SKIP_BUILD = 'true';
+            console.log('[wdio-arm-env] node-llama-cpp missing; using existing dist-electron with SKIP_BUILD=true');
+        }
+    }
+
+    if (!process.env.CHROMEDRIVER_PATH) {
+        const chromedriverBinary = resolveArmChromedriver(projectRoot);
+        process.env.CHROMEDRIVER_PATH = chromedriverBinary;
+        console.log(`[wdio-arm-env] Using ARM Chromedriver at ${chromedriverBinary}`);
+    }
+}
+
+module.exports = {
+    applyArmWdioEnvironment,
+    isTruthyEnv,
+    resolveArmChromedriver,
+};


### PR DESCRIPTION
## Summary
- Add Linux ARM64 auto-configuration for WDIO runs via new `scripts/wdio-arm-env.cjs` (auto CI/Xvfb mode, ARM Chromedriver resolution, cache support, and build-skip fallback when optional llama dependency is unavailable).
- Fix CI/Xvfb ordering risk by making WDIO Electron args/service config read `CI` dynamically at runtime and applying ARM env setup before config consumers.
- Improve robustness and docs: consistent `SKIP_BUILD` truthy parsing across runners/configs, fallback download/extract tools (`curl`/`wget`, `unzip`/`python3`), and updated AI-agent/contributor guidance for headless ARM workflows.

## Verification
- `npm run build` ✅
- `npm run lint` ✅ (warnings only; no new lint errors introduced)
- `npm run test:headless:auto` ⚠️ failed in `tests/integration/hotkeys.integration.test.ts` (voiceChat assertions)
- `npm run test:integration -- --spec tests/integration/hotkeys.integration.test.ts` ⚠️ same voiceChat failures reproduced
- `npm run test:integration -- --spec tests/integration/options-window.integration.test.ts` ✅
- `npm run test:e2e:spec -- --spec tests/e2e/auth.spec.ts` ✅

## Notes
- The integration failure reproduces in a test area unrelated to this change set (voice hotkey integration assertions) and was observed prior to this hardening pass.