### PR TITLE
chore: release v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,12 @@ For full details, please read our [**Privacy Policy**](docs/PRIVACY.md) and [**S
 - **Tabbed conversations** to keep multiple chats open at once. ([#72](https://github.com/bwendell/gemini-desktop/issues/72))
 - **Release notes discoverability** via Help menu entry and update toast action buttons.
 
-### v0.9.0 — Peek & Hide
+### v0.9.0 — Peek & Hide, Hotkeys & Fixes
 
 - **Peek and Hide toggle** to quickly show/hide the app without losing context. ([#91](https://github.com/bwendell/gemini-desktop/issues/91))
+- **Voice chat hotkey** wired to active tab mic. ([#117](https://github.com/bwendell/gemini-desktop/issues/117))
+- **Updated default hotkeys** — Quick Chat and Peek and Hide use new, conflict-free defaults.
+- **macOS fixes** — native Edit menu for copy/paste, tray icon handling, and window frame.
 
 ### Future Work
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gemini-desktop",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gemini-desktop",
-            "version": "0.8.0",
+            "version": "0.9.0",
             "dependencies": {
                 "dbus-next": "^0.10.2",
                 "electron-log": "^5.4.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A desktop wrapper for Google Gemini with enhanced features",
     "author": "Ben Wendell <github@benwendell.com>",
     "private": true,
-    "version": "0.8.0",
+    "version": "0.9.0",
     "type": "module",
     "main": "dist-electron/main/main.cjs",
     "keywords": [


### PR DESCRIPTION
## Release v0.9.0

Bumps version to 0.9.0 and updates the README roadmap.

### Key Changes
- **Peek and Hide toggle** ([#99](https://github.com/bwendell/gemini-desktop/pull/99), [#95](https://github.com/bwendell/gemini-desktop/pull/95), [#104](https://github.com/bwendell/gemini-desktop/pull/104))
- **Updated default hotkeys** — Quick Chat ([#101](https://github.com/bwendell/gemini-desktop/pull/101)), Peek and Hide ([#104](https://github.com/bwendell/gemini-desktop/pull/104))
- **Voice chat hotkey** wired to active tab mic ([#117](https://github.com/bwendell/gemini-desktop/pull/117))
- **macOS fixes** — native Edit menu ([#126](https://github.com/bwendell/gemini-desktop/pull/126)), tray icon ([#124](https://github.com/bwendell/gemini-desktop/pull/124))
- **Text prediction fix** — gate native LLM init ([#125](https://github.com/bwendell/gemini-desktop/pull/125))
- **CI fix** — prevent duplicate runs ([#120](https://github.com/bwendell/gemini-desktop/pull/120))
- **E2E improvements** — breadcrumbs, artifact capture, reduced waits ([#115](https://github.com/bwendell/gemini-desktop/pull/115), [#116](https://github.com/bwendell/gemini-desktop/pull/116), [#118](https://github.com/bwendell/gemini-desktop/pull/118), [#122](https://github.com/bwendell/gemini-desktop/pull/122))