### PR TITLE
chore: release v0.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ For full details, please read our [**Privacy Policy**](docs/PRIVACY.md) and [**S
 - **Updated default hotkeys** — Quick Chat and Peek and Hide use new, conflict-free defaults.
 - **macOS fixes** — native Edit menu for copy/paste, tray icon handling, and window frame.
 
+### v0.9.1 — Bugfix Release
+
+- **macOS menubar icon fix** — use template tray assets to avoid stretching. ([#132](https://github.com/bwendell/gemini-desktop/issues/132), [#134](https://github.com/bwendell/gemini-desktop/pull/134))
+- **Text prediction setup fix** — handle packaged LLM fallback without export errors. ([#133](https://github.com/bwendell/gemini-desktop/issues/133), [#135](https://github.com/bwendell/gemini-desktop/pull/135))
+
 ### Future Work
 
 - **Investigate AI Studio support** and feasibility for a better Gemini Live experience. ([#90](https://github.com/bwendell/gemini-desktop/issues/90))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gemini-desktop",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gemini-desktop",
-            "version": "0.9.0",
+            "version": "0.9.1",
             "dependencies": {
                 "dbus-next": "^0.10.2",
                 "electron-log": "^5.4.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A desktop wrapper for Google Gemini with enhanced features",
     "author": "Ben Wendell <github@benwendell.com>",
     "private": true,
-    "version": "0.9.0",
+    "version": "0.9.1",
     "type": "module",
     "main": "dist-electron/main/main.cjs",
     "keywords": [


### PR DESCRIPTION
## Release v0.9.1
Bugfix release addressing issues 132 and 133.

### Key Changes
- Fix macOS menubar icon stretching by using template tray assets. ([#132](https://github.com/bwendell/gemini-desktop/issues/132), [#134](https://github.com/bwendell/gemini-desktop/pull/134))
- Fix text prediction setup error for packaged LLM fallback. ([#133](https://github.com/bwendell/gemini-desktop/issues/133), [#135](https://github.com/bwendell/gemini-desktop/pull/135))