### PR TITLE
chore: release v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,15 +202,10 @@ For full details, please read our [**Privacy Policy**](docs/PRIVACY.md) and [**S
 - **macOS menubar icon fix** — use template tray assets to avoid stretching. ([#132](https://github.com/bwendell/gemini-desktop/issues/132), [#134](https://github.com/bwendell/gemini-desktop/pull/134))
 - **Text prediction setup fix** — handle packaged LLM fallback without export errors. ([#133](https://github.com/bwendell/gemini-desktop/issues/133), [#135](https://github.com/bwendell/gemini-desktop/pull/135))
 
-### v0.9.2 — Bugfix Release
+### v0.10.0 — Bugfix Release
 
 - **Auto-update reliability on macOS** — fix the update flow that fails with a generic “auto-update service encountered an error” dialog during 0.9.x upgrades. ([#150](https://github.com/bwendell/gemini-desktop/issues/150), [#174](https://github.com/bwendell/gemini-desktop/pull/174))
 - **Linux launch stability on modern distros** — prevent the V8 sandbox/native module memory conflict that causes a segmentation fault on KDE Wayland systems like openSUSE Leap 16. ([#158](https://github.com/bwendell/gemini-desktop/issues/158), [#176](https://github.com/bwendell/gemini-desktop/pull/176))
-
-### v0.10.0 — Fixes & Updates
-
-- **Native Windows ARM64 build** — ship an ARM64 installer so Windows on ARM devices can run Gemini Desktop without emulation. ([#151](https://github.com/bwendell/gemini-desktop/issues/151), [#170](https://github.com/bwendell/gemini-desktop/pull/170))
-- **Contributor guide** — add CONTRIBUTING.md with dev setup, test commands, and contribution expectations so new contributors don’t have to hunt for process details. ([#169](https://github.com/bwendell/gemini-desktop/issues/169))
 
 ### v0.11.0 — Startup Experience
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gemini-desktop",
-    "version": "0.9.2",
+    "version": "0.10.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gemini-desktop",
-            "version": "0.9.2",
+            "version": "0.10.0",
             "dependencies": {
                 "dbus-next": "^0.10.2",
                 "electron-log": "^5.4.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A desktop wrapper for Google Gemini with enhanced features",
     "author": "Ben Wendell <github@benwendell.com>",
     "private": true,
-    "version": "0.9.2",
+    "version": "0.10.0",
     "type": "module",
     "main": "dist-electron/main/main.cjs",
     "keywords": [


### PR DESCRIPTION
## Release v0.10.0

Bugfix release addressing issues 150 and 158.

### Key Changes

- Fix macOS auto-update reliability by routing manual download updates through the GitHub release flow. ([#150](https://github.com/bwendell/gemini-desktop/issues/150), [#174](https://github.com/bwendell/gemini-desktop/pull/174))
- Fix Linux launch stability on KDE Wayland by avoiding V8 sandbox/native module memory conflicts and adding a restart flow. ([#158](https://github.com/bwendell/gemini-desktop/issues/158), [#176](https://github.com/bwendell/gemini-desktop/pull/176))