### PR TITLE
fix(updater): restore Windows x64 update checks in v0.10.0

### DIFF
--- a/src/main/managers/updateManager.ts
+++ b/src/main/managers/updateManager.ts
@@ -164,7 +164,7 @@ export default class UpdateManager {
             updater.autoInstallOnAppQuit = true;
 
             if (process.platform === 'win32') {
-                updater.channel = process.arch === 'arm64' ? 'arm64' : 'x64';
+                updater.channel = process.arch === 'arm64' ? 'latest-arm64' : 'latest-x64';
                 updater.allowDowngrade = false;
             }
 

--- a/tests/unit/main/updateManager.test.ts
+++ b/tests/unit/main/updateManager.test.ts
@@ -191,24 +191,24 @@ describe('UpdateManager', () => {
         expect(autoUpdater.checkForUpdatesAndNotify).toHaveBeenCalled();
     });
 
-    it('uses the x64 update channel on Windows', async () => {
+    it('uses the latest-x64 update channel on Windows', async () => {
         (app as any).isPackaged = true;
         updateManager = new UpdateManager(mockSettingsStore);
 
         await updateManager.checkForUpdates();
 
-        expect(autoUpdater.channel).toBe('x64');
+        expect(autoUpdater.channel).toBe('latest-x64');
         expect(autoUpdater.allowDowngrade).toBe(false);
     });
 
-    it('uses the arm64 update channel on Windows arm64', async () => {
+    it('uses the latest-arm64 update channel on Windows arm64', async () => {
         Object.defineProperty(process, 'arch', { value: 'arm64', configurable: true });
         (app as any).isPackaged = true;
         updateManager = new UpdateManager(mockSettingsStore);
 
         await updateManager.checkForUpdates();
 
-        expect(autoUpdater.channel).toBe('arm64');
+        expect(autoUpdater.channel).toBe('latest-arm64');
         expect(autoUpdater.allowDowngrade).toBe(false);
     });
 


### PR DESCRIPTION
## Summary
- Fixes the Windows updater channel mapping introduced in #170 by using `latest-x64` / `latest-arm64` in `UpdateManager`.
- Aligns runtime channel selection with published release metadata (`latest-x64.yml` and `latest-arm64.yml`) so manual update checks no longer fail with the generic auto-update error toast.
- Updates unit tests to assert the corrected Windows channel values.

## Root Cause
PR #170 changed Windows channel names to `x64` / `arm64`, but release metadata is published as `latest-x64.yml` / `latest-arm64.yml` (plus `latest.yml`). That mismatch causes updater channel-file lookup failures during manual checks, which then surface as `The auto-update service encountered an error. Please try again later.`

## Verification
- `npx vitest tests/unit/main/updateManager.test.ts`
- `npm run build`