### PR TITLE
build(release): add Windows legacy updater metadata aliases

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -322,6 +322,7 @@ jobs:
                   # once the installed base has moved off v0.10.0 and no longer requests arch-only channel files.
                   Copy-Item -Path latest.yml -Destination latest-arm64.yml -Force
                   Copy-Item -Path latest-arm64.yml -Destination arm64.yml -Force
+                  Remove-Item -Path latest.yml -Force
               shell: pwsh
 
             - name: Generate Checksums

--- a/tests/unit/main/releaseWorkflowAliases.test.ts
+++ b/tests/unit/main/releaseWorkflowAliases.test.ts
@@ -1,30 +1,28 @@
 import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const workflowPath = path.resolve(process.cwd(), '.github/workflows/_release.yml');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const workflowPath = path.resolve(__dirname, '../../..', '.github/workflows/_release.yml');
+const workflow = fs.readFileSync(workflowPath, 'utf8');
 
 describe('release workflow Windows metadata aliases', () => {
     it('creates and uploads x64 alias metadata in windows-x64 job', () => {
-        const workflow = fs.readFileSync(workflowPath, 'utf8');
-
         expect(workflow).toContain('name: Prepare Windows update metadata (x64)');
         expect(workflow).toContain('Copy-Item -Path latest-x64.yml -Destination x64.yml -Force');
         expect(workflow).toContain('release/x64.yml');
     });
 
     it('creates and uploads arm64 alias metadata in windows-arm64 job', () => {
-        const workflow = fs.readFileSync(workflowPath, 'utf8');
-
         expect(workflow).toContain('name: Prepare Windows update metadata (arm64)');
         expect(workflow).toContain('Copy-Item -Path latest.yml -Destination latest-arm64.yml -Force');
         expect(workflow).toContain('Copy-Item -Path latest-arm64.yml -Destination arm64.yml -Force');
+        expect(workflow).toContain('Remove-Item -Path latest.yml -Force');
         expect(workflow).toContain('release/arm64.yml');
     });
 
     it('documents temporary compatibility window for removing aliases', () => {
-        const workflow = fs.readFileSync(workflowPath, 'utf8');
-
         expect(workflow).toContain('TODO(v0.10.x cleanup): Remove legacy x64.yml/arm64.yml aliases');
         expect(workflow).toContain('after ~3-4 releases past v0.10.1');
     });


### PR DESCRIPTION
## Summary
- Updates `.github/workflows/_release.yml` to auto-generate and upload legacy Windows updater metadata aliases (`x64.yml` and `arm64.yml`) alongside existing `latest-x64.yml` and `latest-arm64.yml`.
- Adds explicit TODO notes in both Windows metadata preparation steps documenting why aliases exist and when they can be removed (around 3-4 releases after `v0.10.1`).
- Adds a unit test (`tests/unit/main/releaseWorkflowAliases.test.ts`) that validates the workflow includes alias creation, upload entries, and the temporary-compatibility TODO guidance.

## Why
`v0.10.0` clients can request arch-only channel metadata (`x64.yml` / `arm64.yml`), while newer builds use `latest-*` metadata names. Publishing both keeps existing users upgradable while preventing this compatibility gap from recurring in future releases.

## Verification
- `npx vitest run --config config/vitest/vitest.electron.config.ts tests/unit/main/releaseWorkflowAliases.test.ts`
- `npx vitest run --config config/vitest/vitest.electron.config.ts tests/unit/main/updateManager.test.ts tests/unit/main/releaseWorkflowAliases.test.ts`
- `npm run build`