### PR TITLE
fix(ci): add resilient retries for dependency install steps

### DIFF
--- a/.github/actions/retry-command/action.yml
+++ b/.github/actions/retry-command/action.yml
@@ -23,13 +23,18 @@ runs:
     steps:
         - name: Run command with retry
           shell: bash
+          env:
+              MAX_ATTEMPTS: ${{ inputs.max_attempts }}
+              INITIAL_BACKOFF_SECONDS: ${{ inputs.initial_backoff_seconds }}
+              BACKOFF_MULTIPLIER: ${{ inputs.backoff_multiplier }}
+              COMMAND: ${{ inputs.command }}
           run: |
               set -euo pipefail
 
-              max_attempts='${{ inputs.max_attempts }}'
-              delay='${{ inputs.initial_backoff_seconds }}'
-              multiplier='${{ inputs.backoff_multiplier }}'
-              command='${{ inputs.command }}'
+              max_attempts="$MAX_ATTEMPTS"
+              delay="$INITIAL_BACKOFF_SECONDS"
+              multiplier="$BACKOFF_MULTIPLIER"
+              command="$COMMAND"
 
               if ! [[ "$max_attempts" =~ ^[0-9]+$ ]] || [ "$max_attempts" -lt 1 ]; then
                   echo "max_attempts must be a positive integer. Received: $max_attempts"

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -50,9 +50,6 @@ jobs:
               uses: ./.github/actions/retry-command
               with:
                   command: npm ci --prefer-offline
-                  max_attempts: '3'
-                  initial_backoff_seconds: '10'
-                  backoff_multiplier: '2'
 
             - name: Build Frontend
               run: npm run build

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -55,9 +55,6 @@ jobs:
               uses: ./.github/actions/retry-command
               with:
                   command: npm ci --prefer-offline
-                  max_attempts: '3'
-                  initial_backoff_seconds: '10'
-                  backoff_multiplier: '2'
 
             - name: Download Frontend Build
               uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -134,9 +131,6 @@ jobs:
               uses: ./.github/actions/retry-command
               with:
                   command: npm ci --prefer-offline
-                  max_attempts: '3'
-                  initial_backoff_seconds: '10'
-                  backoff_multiplier: '2'
 
             - name: Download Frontend Build
               uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -210,9 +204,6 @@ jobs:
               uses: ./.github/actions/retry-command
               with:
                   command: npm ci --prefer-offline
-                  max_attempts: '3'
-                  initial_backoff_seconds: '10'
-                  backoff_multiplier: '2'
 
             - name: Download Frontend Build
               uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -305,9 +296,6 @@ jobs:
               uses: ./.github/actions/retry-command
               with:
                   command: npm ci --prefer-offline
-                  max_attempts: '3'
-                  initial_backoff_seconds: '10'
-                  backoff_multiplier: '2'
 
             - name: Download Frontend Build
               uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -401,9 +389,6 @@ jobs:
               uses: ./.github/actions/retry-command
               with:
                   command: npm ci --prefer-offline
-                  max_attempts: '3'
-                  initial_backoff_seconds: '10'
-                  backoff_multiplier: '2'
 
             - name: Download Frontend Build
               uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -68,9 +68,6 @@ jobs:
               uses: ./.github/actions/retry-command
               with:
                   command: npm ci --prefer-offline
-                  max_attempts: '3'
-                  initial_backoff_seconds: '10'
-                  backoff_multiplier: '2'
 
             # Download build artifacts from _build.yml
             - name: Download Frontend Build
@@ -137,9 +134,6 @@ jobs:
               uses: ./.github/actions/retry-command
               with:
                   command: npm ci --prefer-offline
-                  max_attempts: '3'
-                  initial_backoff_seconds: '10'
-                  backoff_multiplier: '2'
 
             - name: Download Frontend Build
               uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -196,9 +190,6 @@ jobs:
               uses: ./.github/actions/retry-command
               with:
                   command: npm ci --prefer-offline
-                  max_attempts: '3'
-                  initial_backoff_seconds: '10'
-                  backoff_multiplier: '2'
 
             - name: Download Frontend Build
               uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -260,9 +251,6 @@ jobs:
               uses: ./.github/actions/retry-command
               with:
                   command: npm ci --prefer-offline
-                  max_attempts: '3'
-                  initial_backoff_seconds: '10'
-                  backoff_multiplier: '2'
 
             - name: Download Frontend Build
               uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -339,9 +327,6 @@ jobs:
               uses: ./.github/actions/retry-command
               with:
                   command: npm ci --prefer-offline
-                  max_attempts: '3'
-                  initial_backoff_seconds: '10'
-                  backoff_multiplier: '2'
 
             - name: Download Frontend Build
               uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -412,9 +397,6 @@ jobs:
               uses: ./.github/actions/retry-command
               with:
                   command: npm ci --prefer-offline
-                  max_attempts: '3'
-                  initial_backoff_seconds: '10'
-                  backoff_multiplier: '2'
 
             - name: Download Frontend Build
               uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -506,9 +488,6 @@ jobs:
               uses: ./.github/actions/retry-command
               with:
                   command: npm ci --prefer-offline
-                  max_attempts: '3'
-                  initial_backoff_seconds: '10'
-                  backoff_multiplier: '2'
 
             # Download build artifacts from _build.yml
             - name: Download Frontend Build


### PR DESCRIPTION
## Summary
- add a reusable local composite action (`.github/actions/retry-command`) that runs shell commands with bounded retries and exponential backoff
- replace all `npm ci` workflow steps in reusable build/test/release workflows with the retry action (using `npm ci --prefer-offline`) and configure npm fetch retries globally
- harden Linux apt setup in `_test.yml` by adding `Acquire::Retries` and HTTP/HTTPS timeout options to reduce transient mirror/network failures

## Why
Recent CI flakes (including transient `502` during dependency install) were recoverable failures. This change adds targeted retries for network-sensitive package installation without masking persistent failures.

## Verification
- `npx prettier --check .github/workflows/_build.yml .github/workflows/_test.yml .github/workflows/_release.yml .github/actions/retry-command/action.yml`
- `npm run lint` (passes; repository has pre-existing warnings only)
- `npm run build` (passes)
- `npm run test` (passes: 55 files, 647 passed, 4 skipped)
- `lsp_diagnostics` clean for all modified YAML files

## Notes
- no renderer/main app runtime behavior changed; this PR is CI workflow hardening only
- retries are bounded (`max_attempts: 3`) with exponential backoff to avoid hiding persistent failures