### PR TITLE
ci: set Windows release e2e and integration timeouts to 30 minutes

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -232,6 +232,7 @@ jobs:
             - name: Run Release E2E Tests
               run: npm run test:e2e:release
               shell: bash
+              timeout-minutes: 30
 
             - name: Prepare Windows update metadata (x64)
               run: |
@@ -324,6 +325,7 @@ jobs:
             - name: Run Release E2E Tests
               run: npm run test:e2e:release
               shell: bash
+              timeout-minutes: 30
 
             - name: Prepare Windows update metadata (arm64)
               run: |

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -167,14 +167,20 @@ jobs:
         name: Integration Tests (${{ matrix.os }})
         needs: unit-tests
         runs-on: ${{ matrix.os }}
-        timeout-minutes: 25
+        timeout-minutes: ${{ matrix.timeout_minutes }}
         permissions:
             contents: read
 
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-latest, macos-latest]
+                include:
+                    - os: ubuntu-latest
+                      timeout_minutes: 25
+                    - os: windows-latest
+                      timeout_minutes: 30
+                    - os: macos-latest
+                      timeout_minutes: 25
 
         steps:
             - name: Checkout Code


### PR DESCRIPTION
## Summary
- set Windows release E2E steps in `.github/workflows/_release.yml` to explicit `timeout-minutes: 30` for both x64 and arm64 jobs
- update `.github/workflows/_test.yml` integration matrix so only `windows-latest` runs at 30 minutes while Linux/macOS remain at 25 minutes
- keep workflow formatting/style consistent and limit scope to CI timeout configuration

## Validation
- `npm install`
- `npx prettier --check .github/workflows/_test.yml .github/workflows/_release.yml`
- `npm run lint` (passes with existing repo warnings only; no new errors)
- `npm run build`