### PR TITLE
chore: release v0.11.1

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,6 +36,13 @@ Priorities may shift based on user feedback, upstream Gemini changes, and platfo
 - **Test infrastructure hardening** — standardize WDIO config inheritance, remove flaky waits, and improve assertion/failure context helpers for more deterministic CI. ([#180](https://github.com/bwendell/gemini-desktop/pull/180), [#186](https://github.com/bwendell/gemini-desktop/pull/186), [#190](https://github.com/bwendell/gemini-desktop/pull/190), [#185](https://github.com/bwendell/gemini-desktop/pull/185))
 - **Quality and maintenance updates** — enforce lint checks in pre-commit hooks, remediate npm audit vulnerabilities, reduce E2E lint noise, and add docs updates/deprecations. ([#189](https://github.com/bwendell/gemini-desktop/pull/189), [#187](https://github.com/bwendell/gemini-desktop/pull/187), [#191](https://github.com/bwendell/gemini-desktop/pull/191), [#192](https://github.com/bwendell/gemini-desktop/pull/192))
 
+### v0.11.1 — Refresh Continuity & Release Stability
+
+- **Return to previous chat on refresh** — preserve each tab's active Gemini URL and restore that exact conversation after refresh instead of defaulting to the Gemini homepage. ([#198](https://github.com/bwendell/gemini-desktop/issues/198), [#200](https://github.com/bwendell/gemini-desktop/pull/200))
+- **Preload bridge architecture refactor** — split preload bridge APIs into domain modules for clearer boundaries and easier long-term maintenance. ([#202](https://github.com/bwendell/gemini-desktop/pull/202))
+- **Release and test reliability improvements** — dedupe zoom integration coverage and increase Windows release/integration timeout limits to reduce flaky release gates. ([#203](https://github.com/bwendell/gemini-desktop/pull/203), [#205](https://github.com/bwendell/gemini-desktop/pull/205))
+- **Documentation and developer workflow updates** — refresh architecture references and setup guidance for cleaner contributor onboarding and handoff context. ([#206](https://github.com/bwendell/gemini-desktop/pull/206), [#201](https://github.com/bwendell/gemini-desktop/pull/201), [#199](https://github.com/bwendell/gemini-desktop/pull/199), [#197](https://github.com/bwendell/gemini-desktop/pull/197), [#194](https://github.com/bwendell/gemini-desktop/pull/194))
+
 ## Near-Term Focus
 
 - Continue strengthening release quality and upgrade reliability across platforms.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gemini-desktop",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gemini-desktop",
-            "version": "0.11.0",
+            "version": "0.11.1",
             "dependencies": {
                 "dbus-next": "^0.10.2",
                 "electron-log": "^5.4.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A desktop wrapper for Google Gemini with enhanced features",
     "author": "Ben Wendell <github@benwendell.com>",
     "private": true,
-    "version": "0.11.0",
+    "version": "0.11.1",
     "type": "module",
     "main": "dist-electron/main/main.cjs",
     "keywords": [


### PR DESCRIPTION
## Release v0.11.1

This PR prepares the `v0.11.1` release by bumping version metadata and finalizing roadmap notes for all merged PRs since `v0.11.0`.

### Key Changes
- Bump app version from `0.11.0` to `0.11.1` in `package.json` and `package-lock.json`.
- Expand the roadmap `v0.11.1` section in `docs/ROADMAP.md` to summarize shipped work merged since `v0.11.0`:
  - return to previous chat on refresh (issue [#198](https://github.com/bwendell/gemini-desktop/issues/198), implementation [#200](https://github.com/bwendell/gemini-desktop/pull/200))
  - preload bridge architecture refactor [#202](https://github.com/bwendell/gemini-desktop/pull/202)
  - release/test reliability updates [#203](https://github.com/bwendell/gemini-desktop/pull/203), [#205](https://github.com/bwendell/gemini-desktop/pull/205)
  - documentation and contributor workflow updates [#206](https://github.com/bwendell/gemini-desktop/pull/206), [#201](https://github.com/bwendell/gemini-desktop/pull/201), [#199](https://github.com/bwendell/gemini-desktop/pull/199), [#197](https://github.com/bwendell/gemini-desktop/pull/197), [#194](https://github.com/bwendell/gemini-desktop/pull/194)

### Verification
- `npm run lint` (passes with existing repository warnings only)
- `npm run test` (55 files passed, 647 tests passed, 4 skipped)
- `npm run build` (successful)