### PR TITLE
feat: support Windows Alt+Space hotkey capture

### DIFF
--- a/src/main/AGENTS.md
+++ b/src/main/AGENTS.md
@@ -19,6 +19,11 @@ Primary files and folders:
 All managers are injected via `ApplicationContext`. Do not use global mutable manager singletons.
 For architecture details, see `docs/ARCHITECTURE.md` (Manager Architecture section).
 
+### Windows-reserved hotkey capture pattern
+
+When a shortcut must work around Windows-reserved behavior (for example `Alt+Space`), keep the existing hotkey persistence/registration path intact and add the platform-specific capture/suppression logic in a dedicated manager under `src/main/managers/`.
+Attach that manager centrally from `main.ts` with `app.on('browser-window-created', ...)` so every `BrowserWindow` gets the same `before-input-event` / `system-context-menu` handling without duplicating window-specific code.
+
 ## IPC Handler Pattern
 
 Handlers extend `BaseIpcHandler` and follow lifecycle: `register()` → optional `initialize()` → `unregister()`.
@@ -35,6 +40,7 @@ See `src/main/managers/ipc/BaseIpcHandler.ts` and `docs/ARCHITECTURE.md` (IPC Ha
 ## Common Mistakes
 
 - Using global mutable state for managers instead of DI via `ApplicationContext`
+- Embedding Windows-specific hotkey suppression directly in individual window classes instead of a shared manager attached from `main.ts`
 - Forgetting `unregister()` cleanup for IPC handlers
 - Sending to destroyed windows without checking `isDestroyed()` first
 

--- a/src/main/ApplicationContext.ts
+++ b/src/main/ApplicationContext.ts
@@ -8,6 +8,7 @@ import type LlmManager from './managers/llmManager';
 import type NotificationManager from './managers/notificationManager';
 import type ExportManager from './managers/exportManager';
 import type MenuManager from './managers/menuManager';
+import type { WindowsHotkeyCaptureManager } from './managers/windowsHotkeyCaptureManager';
 
 export interface CoreManagers {
     readonly windowManager: WindowManager;
@@ -18,6 +19,7 @@ export interface CoreManagers {
     readonly llmManager: LlmManager;
     readonly exportManager: ExportManager;
     readonly ipcManager: IpcManager;
+    readonly windowsHotkeyCaptureManager: WindowsHotkeyCaptureManager;
 }
 
 export interface ReadyManagers {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -80,6 +80,7 @@ import NotificationManager, { type NotificationSettings } from './managers/notif
 import UpdateManager, { AutoUpdateSettings } from './managers/updateManager';
 import ExportManager from './managers/exportManager';
 import LlmManager from './managers/llmManager';
+import { WindowsHotkeyCaptureManager } from './managers/windowsHotkeyCaptureManager';
 import SettingsStore from './store';
 import type { ApplicationContext, E2EGlobals, ReadyManagers } from './ApplicationContext';
 
@@ -141,6 +142,10 @@ function initializeManagers(): void {
     const hotkeyManager = new HotkeyManager(windowManager);
     logger.debug('initializeManagers() - HotkeyManager created');
 
+    logger.debug('initializeManagers() - creating WindowsHotkeyCaptureManager');
+    const windowsHotkeyCaptureManager = new WindowsHotkeyCaptureManager(hotkeyManager);
+    logger.debug('initializeManagers() - WindowsHotkeyCaptureManager created');
+
     // Create tray and badge managers
     logger.debug('initializeManagers() - creating TrayManager');
     const trayManager = new TrayManager(windowManager);
@@ -178,8 +183,22 @@ function initializeManagers(): void {
     logger.debug('initializeManagers() - ExportManager created');
 
     logger.debug('initializeManagers() - creating IpcManager');
-    const ipcManager = new IpcManager(windowManager, hotkeyManager, updateManager, exportManager, llmManager, null);
+    const ipcManager = new IpcManager(
+        windowManager,
+        hotkeyManager,
+        updateManager,
+        exportManager,
+        llmManager,
+        null,
+        undefined,
+        undefined,
+        windowsHotkeyCaptureManager
+    );
     logger.debug('initializeManagers() - IpcManager created');
+
+    app.on('browser-window-created', (_event, window) => {
+        windowsHotkeyCaptureManager.attachWindow(window);
+    });
 
     appContext = {
         windowManager,
@@ -190,6 +209,7 @@ function initializeManagers(): void {
         llmManager,
         exportManager,
         ipcManager,
+        windowsHotkeyCaptureManager,
         menuManager: null,
         notificationManager: null,
     };

--- a/src/main/managers/hotkeyManager.ts
+++ b/src/main/managers/hotkeyManager.ts
@@ -290,6 +290,12 @@ export default class HotkeyManager {
         return this._accelerators[id];
     }
 
+    ownsRegisteredGlobalAccelerator(accelerator: string): boolean {
+        return Array.from(this._registeredShortcuts.values()).some(
+            (registeredAccelerator) => registeredAccelerator === accelerator
+        );
+    }
+
     /**
      * Get full settings including both enabled states and accelerators.
      *

--- a/src/main/managers/ipc/HotkeyIpcHandler.ts
+++ b/src/main/managers/ipc/HotkeyIpcHandler.ts
@@ -23,6 +23,7 @@ import {
     type HotkeySettings,
     type PlatformHotkeyStatus,
 } from '../../../shared/types/hotkeys';
+import type { HotkeyCaptureResult } from '../../../shared/types/hotkey-capture';
 import { getActivationSignalStats, clearActivationSignalHistory } from '../../utils/dbusFallback';
 
 /** Whether to enable test-only D-Bus activation signal IPC handlers */
@@ -62,6 +63,14 @@ export class HotkeyIpcHandler extends BaseIpcHandler {
         // Get full hotkey settings (enabled + accelerators)
         ipcMain.handle(IPC_CHANNELS.HOTKEYS_FULL_SETTINGS_GET, (): HotkeySettings => {
             return this._handleGetFullSettings();
+        });
+
+        ipcMain.handle(IPC_CHANNELS.HOTKEYS_CAPTURE_ACCELERATOR, (event): Promise<HotkeyCaptureResult> => {
+            return this._handleCaptureAccelerator(event);
+        });
+
+        ipcMain.on(IPC_CHANNELS.HOTKEYS_CAPTURE_CANCEL, (event) => {
+            this._handleCancelCapture(event);
         });
 
         // Get current platform hotkey status (Wayland/Portal info)
@@ -375,6 +384,24 @@ export class HotkeyIpcHandler extends BaseIpcHandler {
         this.broadcastToAllWindows(IPC_CHANNELS.HOTKEYS_ACCELERATOR_CHANGED, accelerators);
     }
 
+    private _handleCaptureAccelerator(event: Electron.IpcMainInvokeEvent): Promise<HotkeyCaptureResult> {
+        const win = this.getWindowFromEvent(event);
+        if (!win || !this.deps.windowsHotkeyCaptureManager) {
+            return Promise.resolve({ status: 'cancelled', accelerator: null });
+        }
+
+        return this.deps.windowsHotkeyCaptureManager.beginCapture(win.id);
+    }
+
+    private _handleCancelCapture(event: Electron.IpcMainEvent): void {
+        const win = this.getWindowFromEvent(event);
+        if (!win || !this.deps.windowsHotkeyCaptureManager) {
+            return;
+        }
+
+        this.deps.windowsHotkeyCaptureManager.cancelCapture(win.id);
+    }
+
     /** Unregister all IPC handlers. */
     unregister(): void {
         ipcMain.removeHandler(IPC_CHANNELS.HOTKEYS_INDIVIDUAL_GET);
@@ -382,6 +409,8 @@ export class HotkeyIpcHandler extends BaseIpcHandler {
         ipcMain.removeHandler(IPC_CHANNELS.HOTKEYS_ACCELERATOR_GET);
         ipcMain.removeAllListeners(IPC_CHANNELS.HOTKEYS_ACCELERATOR_SET);
         ipcMain.removeHandler(IPC_CHANNELS.HOTKEYS_FULL_SETTINGS_GET);
+        ipcMain.removeHandler(IPC_CHANNELS.HOTKEYS_CAPTURE_ACCELERATOR);
+        ipcMain.removeAllListeners(IPC_CHANNELS.HOTKEYS_CAPTURE_CANCEL);
         ipcMain.removeHandler(IPC_CHANNELS.PLATFORM_HOTKEY_STATUS_GET);
         // Only remove test-only handlers if they were registered
         if (TEST_ONLY_DBUS_SIGNALS_ENABLED) {

--- a/src/main/managers/ipc/types.ts
+++ b/src/main/managers/ipc/types.ts
@@ -11,6 +11,7 @@ import type UpdateManager from '../updateManager';
 import type LlmManager from '../llmManager';
 import type NotificationManager from '../notificationManager';
 import type ExportManager from '../exportManager';
+import type { WindowsHotkeyCaptureManager } from '../windowsHotkeyCaptureManager';
 import type { Logger } from '../../types';
 
 /**
@@ -70,4 +71,5 @@ export interface IpcHandlerDependencies {
     notificationManager?: NotificationManager | null;
     /** Optional export manager for high-quality PDF/MD export */
     exportManager?: ExportManager | null;
+    windowsHotkeyCaptureManager?: WindowsHotkeyCaptureManager | null;
 }

--- a/src/main/managers/ipcManager.ts
+++ b/src/main/managers/ipcManager.ts
@@ -37,6 +37,7 @@ import type UpdateManager from './updateManager';
 import type LlmManager from './llmManager';
 import type NotificationManager from './notificationManager';
 import type ExportManager from './exportManager';
+import type { WindowsHotkeyCaptureManager } from './windowsHotkeyCaptureManager';
 import type { ModelStatus } from './llmManager';
 import type { ThemePreference, Logger } from '../types';
 import { DEFAULT_ACCELERATORS } from '../../shared/types/hotkeys';
@@ -109,7 +110,8 @@ export default class IpcManager {
         llmManager?: LlmManager | null,
         notificationManager?: NotificationManager | null,
         store?: SettingsStore<UserPreferences>,
-        logger?: Logger
+        logger?: Logger,
+        windowsHotkeyCaptureManager?: WindowsHotkeyCaptureManager | null
     ) {
         /* v8 ignore next 16 -- production fallback, tests always inject dependencies */
         const actualStore =
@@ -154,6 +156,7 @@ export default class IpcManager {
             llmManager: llmManager || null,
             notificationManager: notificationManager || null,
             exportManager: exportManager || null,
+            windowsHotkeyCaptureManager: windowsHotkeyCaptureManager || null,
         };
         this.handlerDeps = handlerDeps;
 

--- a/src/main/managers/windowsHotkeyCaptureManager.ts
+++ b/src/main/managers/windowsHotkeyCaptureManager.ts
@@ -1,0 +1,181 @@
+import type { BrowserWindow, Input, Point } from 'electron';
+
+import type HotkeyManager from './hotkeyManager';
+import { acceleratorFromKeyInput } from '../../shared/utils/acceleratorUtils';
+import type { HotkeyCaptureResult } from '../../shared/types/hotkey-capture';
+import { createLogger } from '../utils/logger';
+
+interface CaptureSession {
+    token: symbol;
+    resolve: (result: HotkeyCaptureResult) => void;
+}
+
+interface WindowKeyboardState {
+    lastAltSpaceCandidateAt: number;
+}
+
+const ALT_SPACE_ACCELERATOR = 'Alt+Space';
+const ALT_SPACE_CANDIDATE_WINDOW_MS = 1000;
+
+export class WindowsHotkeyCaptureManager {
+    private readonly logger = createLogger('[WindowsHotkeyCaptureManager]');
+    private readonly sessions = new Map<number, CaptureSession>();
+    private readonly keyboardState = new Map<number, WindowKeyboardState>();
+    private readonly attachedWindows = new Set<number>();
+
+    constructor(
+        private readonly hotkeyManager: HotkeyManager,
+        private readonly platform: NodeJS.Platform = process.platform
+    ) {}
+
+    attachWindow(win: BrowserWindow): void {
+        if (!this.isEnabled() || this.attachedWindows.has(win.id)) {
+            return;
+        }
+
+        this.attachedWindows.add(win.id);
+        this.keyboardState.set(win.id, { lastAltSpaceCandidateAt: 0 });
+
+        win.webContents.on('before-input-event', (event, input) => {
+            this.handleBeforeInputEvent(win.id, event, input as Input);
+        });
+
+        win.on('system-context-menu', (event, point) => {
+            this.handleSystemContextMenu(win, event, point);
+        });
+
+        win.on('closed', () => {
+            this.cancelCapture(win.id);
+            this.keyboardState.delete(win.id);
+            this.attachedWindows.delete(win.id);
+        });
+    }
+
+    beginCapture(windowId: number): Promise<HotkeyCaptureResult> {
+        if (!this.isEnabled()) {
+            return Promise.resolve({ status: 'cancelled', accelerator: null });
+        }
+
+        this.cancelCapture(windowId);
+
+        return new Promise<HotkeyCaptureResult>((resolve) => {
+            this.sessions.set(windowId, {
+                token: Symbol(`capture-${windowId}`),
+                resolve,
+            });
+        });
+    }
+
+    cancelCapture(windowId: number): void {
+        this.finishCapture(windowId, { status: 'cancelled', accelerator: null });
+    }
+
+    private isEnabled(): boolean {
+        return this.platform === 'win32';
+    }
+
+    private handleBeforeInputEvent(windowId: number, event: { preventDefault: () => void }, input: Input): void {
+        if (!this.isEnabled() || input.type !== 'keyDown') {
+            return;
+        }
+
+        if (this.isAltSpaceCandidate(input)) {
+            this.keyboardState.set(windowId, { lastAltSpaceCandidateAt: Date.now() });
+        }
+
+        const accelerator = acceleratorFromKeyInput({
+            ctrlKey: 'control' in input ? Boolean(input.control) : false,
+            metaKey: 'meta' in input ? Boolean(input.meta) : false,
+            altKey: 'alt' in input ? Boolean(input.alt) : false,
+            shiftKey: 'shift' in input ? Boolean(input.shift) : false,
+            key: 'key' in input && typeof input.key === 'string' ? input.key : '',
+            code: 'code' in input && typeof input.code === 'string' ? input.code : '',
+        });
+
+        if (!accelerator) {
+            return;
+        }
+
+        const captureSession = this.sessions.get(windowId);
+        if (!captureSession) {
+            return;
+        }
+
+        event.preventDefault();
+        this.finishCapture(windowId, {
+            status: 'captured',
+            accelerator,
+        });
+    }
+
+    private handleSystemContextMenu(win: BrowserWindow, event: { preventDefault: () => void }, point: Point): void {
+        if (!this.isEnabled()) {
+            return;
+        }
+
+        const captureActive = this.sessions.has(win.id);
+        const registeredAltSpace = this.hotkeyManager.ownsRegisteredGlobalAccelerator(ALT_SPACE_ACCELERATOR);
+        if (!captureActive && !registeredAltSpace) {
+            return;
+        }
+
+        const position = win.getPosition();
+        const keyboardTriggeredAltSpace =
+            position.length >= 2 && this.isLikelyKeyboardAltSpace(win.id, point, position);
+        if (!keyboardTriggeredAltSpace) {
+            return;
+        }
+
+        event.preventDefault();
+
+        if (!captureActive) {
+            return;
+        }
+
+        this.finishCapture(win.id, {
+            status: 'captured',
+            accelerator: ALT_SPACE_ACCELERATOR,
+        });
+    }
+
+    private isAltSpaceCandidate(input: Input): boolean {
+        return (
+            'alt' in input &&
+            Boolean(input.alt) &&
+            'key' in input &&
+            typeof input.key === 'string' &&
+            input.key === 'Alt'
+        );
+    }
+
+    private isLikelyKeyboardAltSpace(windowId: number, point: Point, position: number[]): boolean {
+        const state = this.keyboardState.get(windowId);
+        if (!state) {
+            return false;
+        }
+
+        const [windowX, windowY] = position;
+        if (windowX === undefined || windowY === undefined) {
+            return false;
+        }
+
+        const withinRecentKeyboardWindow = Date.now() - state.lastAltSpaceCandidateAt <= ALT_SPACE_CANDIDATE_WINDOW_MS;
+        const isWindowCorner = windowX === point.x && windowY === point.y + 1;
+
+        return withinRecentKeyboardWindow && isWindowCorner;
+    }
+
+    private finishCapture(windowId: number, result: HotkeyCaptureResult): void {
+        const session = this.sessions.get(windowId);
+        if (!session) {
+            return;
+        }
+
+        this.sessions.delete(windowId);
+        try {
+            session.resolve(result);
+        } catch (error) {
+            this.logger.error('Failed to resolve hotkey capture session:', error);
+        }
+    }
+}

--- a/src/preload/AGENTS.md
+++ b/src/preload/AGENTS.md
@@ -16,6 +16,8 @@ Preload APIs follow three patterns:
 
 Subscription cleanup return functions are mandatory because renderer hooks call them during `useEffect` teardown.
 
+For one-shot native capture flows, prefer an explicit `invoke` method for the capture request and a paired `send` cancellation method for blur/unmount cleanup. Keep these APIs narrow and task-specific (for example `captureNextHotkey()` and `cancelHotkeyCapture()`).
+
 ## Canonical Example
 
 - `src/preload/preload.ts` — Theme API section (`// Theme API`, lines 197-228)

--- a/src/preload/api/hotkeys.ts
+++ b/src/preload/api/hotkeys.ts
@@ -14,6 +14,8 @@ export const hotkeysAPI: Pick<
     | 'getFullHotkeySettings'
     | 'setHotkeyAccelerator'
     | 'onHotkeyAcceleratorsChanged'
+    | 'captureNextHotkey'
+    | 'cancelHotkeyCapture'
 > = {
     getIndividualHotkeys: () => ipcRenderer.invoke(IPC_CHANNELS.HOTKEYS_INDIVIDUAL_GET),
     setIndividualHotkey: (id: HotkeyId, enabled: boolean) =>
@@ -24,4 +26,6 @@ export const hotkeysAPI: Pick<
     setHotkeyAccelerator: (id: HotkeyId, accelerator: string) =>
         ipcRenderer.send(IPC_CHANNELS.HOTKEYS_ACCELERATOR_SET, id, accelerator),
     onHotkeyAcceleratorsChanged: createSubscription<HotkeyAccelerators>(IPC_CHANNELS.HOTKEYS_ACCELERATOR_CHANGED),
+    captureNextHotkey: () => ipcRenderer.invoke(IPC_CHANNELS.HOTKEYS_CAPTURE_ACCELERATOR),
+    cancelHotkeyCapture: () => ipcRenderer.send(IPC_CHANNELS.HOTKEYS_CAPTURE_CANCEL),
 };

--- a/src/renderer/components/options/HotkeyAcceleratorInput.tsx
+++ b/src/renderer/components/options/HotkeyAcceleratorInput.tsx
@@ -9,6 +9,7 @@
 
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import type { HotkeyId } from '../../context/IndividualHotkeysContext';
+import { acceleratorFromKeyInput } from '../../../shared/utils/acceleratorUtils';
 import './hotkeyAcceleratorInput.css';
 
 // ============================================================================
@@ -31,78 +32,6 @@ interface HotkeyAcceleratorInputProps {
 // ============================================================================
 // Helper Functions
 // ============================================================================
-
-/**
- * Convert a keyboard event to an Electron accelerator string.
- */
-function keyEventToAccelerator(event: React.KeyboardEvent): string | null {
-    const parts: string[] = [];
-
-    // Must have at least one modifier
-    if (!event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey) {
-        return null;
-    }
-
-    // Add modifiers (use CommandOrControl for cross-platform)
-    if (event.ctrlKey || event.metaKey) {
-        parts.push('CommandOrControl');
-    }
-    if (event.altKey) {
-        parts.push('Alt');
-    }
-    if (event.shiftKey) {
-        parts.push('Shift');
-    }
-
-    // Skip if only modifier keys are pressed
-    const modifierKeys = ['Control', 'Meta', 'Alt', 'Shift', 'CapsLock', 'NumLock', 'ScrollLock'];
-    if (modifierKeys.includes(event.key)) {
-        return null;
-    }
-
-    // Get the main key
-    let key = '';
-
-    if (event.code.startsWith('Key')) {
-        key = event.code.slice(3); // KeyA -> A
-    } else if (event.code.startsWith('Digit')) {
-        key = event.code.slice(5); // Digit1 -> 1
-    } else if (event.code === 'Space') {
-        key = 'Space';
-    } else if (event.code === 'Enter') {
-        key = 'Enter';
-    } else if (event.code === 'Escape') {
-        return null; // Escape cancels recording
-    } else if (event.code === 'Tab') {
-        key = 'Tab';
-    } else if (event.code === 'Backspace') {
-        key = 'Backspace';
-    } else if (event.code === 'Delete') {
-        key = 'Delete';
-    } else if (event.code.startsWith('Arrow')) {
-        key = event.code.slice(5); // ArrowUp -> Up
-    } else if (event.code.startsWith('F') && /^F\d{1,2}$/.test(event.code)) {
-        key = event.code; // F1-F24
-    } else if (event.code === 'Home') {
-        key = 'Home';
-    } else if (event.code === 'End') {
-        key = 'End';
-    } else if (event.code === 'PageUp') {
-        key = 'PageUp';
-    } else if (event.code === 'PageDown') {
-        key = 'PageDown';
-    } else {
-        // Use the key value for other keys
-        key = event.key.length === 1 ? event.key.toUpperCase() : event.key;
-    }
-
-    if (!key) {
-        return null;
-    }
-
-    parts.push(key);
-    return parts.join('+');
-}
 
 /**
  * Parse an accelerator string into individual key parts for display.
@@ -174,7 +103,20 @@ export function HotkeyAcceleratorInput({
     defaultAccelerator,
 }: HotkeyAcceleratorInputProps) {
     const [isRecording, setIsRecording] = useState(false);
-    const inputRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLButtonElement>(null);
+    const captureRequestIdRef = useRef(0);
+    const captureAbortControllerRef = useRef<AbortController | null>(null);
+    const isWindows = window.electronAPI?.platform === 'win32';
+
+    useEffect(() => {
+        return () => {
+            captureAbortControllerRef.current?.abort();
+            captureAbortControllerRef.current = null;
+            if (window.electronAPI?.cancelHotkeyCapture) {
+                window.electronAPI.cancelHotkeyCapture();
+            }
+        };
+    }, []);
 
     // Focus the input when entering recording mode
     useEffect(() => {
@@ -182,6 +124,45 @@ export function HotkeyAcceleratorInput({
             inputRef.current.focus();
         }
     }, [isRecording]);
+
+    useEffect(() => {
+        if (!isRecording || !isWindows || !window.electronAPI?.captureNextHotkey) {
+            return;
+        }
+
+        const requestId = captureRequestIdRef.current + 1;
+        captureRequestIdRef.current = requestId;
+        const abortController = new AbortController();
+        captureAbortControllerRef.current = abortController;
+
+        void window.electronAPI
+            .captureNextHotkey()
+            .then((result) => {
+                if (abortController.signal.aborted || captureRequestIdRef.current !== requestId) {
+                    return;
+                }
+
+                if (result.status === 'captured' && result.accelerator) {
+                    onAcceleratorChange(hotkeyId, result.accelerator);
+                }
+
+                setIsRecording(false);
+            })
+            .catch(() => {
+                if (abortController.signal.aborted || captureRequestIdRef.current !== requestId) {
+                    return;
+                }
+
+                setIsRecording(false);
+            });
+
+        return () => {
+            abortController.abort();
+            if (captureAbortControllerRef.current === abortController) {
+                captureAbortControllerRef.current = null;
+            }
+        };
+    }, [hotkeyId, isRecording, isWindows, onAcceleratorChange]);
 
     // Handle key down during recording
     const handleKeyDown = useCallback(
@@ -193,21 +174,38 @@ export function HotkeyAcceleratorInput({
 
             // Escape cancels recording
             if (event.key === 'Escape') {
+                if (window.electronAPI?.cancelHotkeyCapture) {
+                    window.electronAPI.cancelHotkeyCapture();
+                }
                 setIsRecording(false);
                 return;
             }
 
-            const accelerator = keyEventToAccelerator(event);
+            if (isWindows) {
+                return;
+            }
+
+            const accelerator = acceleratorFromKeyInput({
+                ctrlKey: event.ctrlKey,
+                metaKey: event.metaKey,
+                altKey: event.altKey,
+                shiftKey: event.shiftKey,
+                key: event.key,
+                code: event.code,
+            });
             if (accelerator) {
                 onAcceleratorChange(hotkeyId, accelerator);
                 setIsRecording(false);
             }
         },
-        [isRecording, hotkeyId, onAcceleratorChange]
+        [hotkeyId, isRecording, isWindows, onAcceleratorChange]
     );
 
     // Handle blur - stop recording
     const handleBlur = useCallback(() => {
+        if (window.electronAPI?.cancelHotkeyCapture) {
+            window.electronAPI.cancelHotkeyCapture();
+        }
         setIsRecording(false);
     }, []);
 
@@ -232,6 +230,7 @@ export function HotkeyAcceleratorInput({
         <div className={`hotkey-accelerator-input ${disabled ? 'disabled' : ''}`}>
             {!isDefault && (
                 <button
+                    type="button"
                     className="reset-button"
                     onClick={resetToDefault}
                     disabled={disabled}
@@ -239,21 +238,23 @@ export function HotkeyAcceleratorInput({
                     title="Reset to default"
                 >
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <title>Reset to default</title>
                         <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
                         <path d="M3 3v5h5" />
                     </svg>
                 </button>
             )}
-            <div
+            <button
                 ref={inputRef}
+                type="button"
                 className={`keycap-container ${isRecording ? 'recording' : ''}`}
                 onClick={startRecording}
                 onKeyDown={handleKeyDown}
                 onBlur={handleBlur}
                 tabIndex={disabled ? -1 : 0}
-                role="button"
                 aria-label={`Keyboard shortcut: ${keyParts.join(' + ')}. Click to change.`}
                 aria-disabled={disabled}
+                disabled={disabled}
             >
                 {isRecording ? (
                     <span className="recording-prompt">
@@ -263,14 +264,16 @@ export function HotkeyAcceleratorInput({
                 ) : (
                     <div className="keycaps">
                         {keyParts.map((part, index) => (
-                            <React.Fragment key={index}>
+                            <React.Fragment
+                                key={`${part}-${keyParts.slice(0, index).filter((existingPart) => existingPart === part).length}`}
+                            >
                                 {index > 0 && <span className="key-separator">+</span>}
                                 <Keycap keyLabel={part} isModifier={index < keyParts.length - 1} />
                             </React.Fragment>
                         ))}
                     </div>
                 )}
-            </div>
+            </button>
         </div>
     );
 }

--- a/src/shared/AGENTS.md
+++ b/src/shared/AGENTS.md
@@ -23,6 +23,8 @@ If you add, rename, or remove a channel or shared payload, update every consumin
 - renderer callers/subscriptions
 - any tests that assert the contract
 
+If you add a one-shot cross-boundary workflow, define the payload/result in `src/shared/types/` and export it from the shared type surface instead of inventing ad hoc inline shapes in preload or renderer code.
+
 For architecture context, read [docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md), especially the **Shared Contracts** section.
 
 ## Canonical Examples

--- a/src/shared/constants/ipc-channels.ts
+++ b/src/shared/constants/ipc-channels.ts
@@ -68,6 +68,8 @@ export const IPC_CHANNELS = {
     HOTKEYS_ACCELERATOR_SET: 'hotkeys:accelerator:set',
     HOTKEYS_ACCELERATOR_CHANGED: 'hotkeys:accelerator:changed',
     HOTKEYS_FULL_SETTINGS_GET: 'hotkeys:full-settings:get',
+    HOTKEYS_CAPTURE_ACCELERATOR: 'hotkeys:capture:accelerator',
+    HOTKEYS_CAPTURE_CANCEL: 'hotkeys:capture:cancel',
 
     // Auto-Update
     AUTO_UPDATE_GET_ENABLED: 'auto-update:get-enabled',

--- a/src/shared/types/hotkey-capture.ts
+++ b/src/shared/types/hotkey-capture.ts
@@ -1,0 +1,4 @@
+export interface HotkeyCaptureResult {
+    status: 'captured' | 'cancelled' | 'timeout';
+    accelerator: string | null;
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -14,6 +14,7 @@ export * from './toast';
 export * from './text-prediction';
 export * from './notifications';
 export * from './tabs';
+export * from './hotkey-capture';
 
 // Re-export ElectronAPI explicitly for easier imports
 export type { ElectronAPI } from './ipc';

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -17,6 +17,7 @@ import type { UpdateInfo, DownloadProgress } from './updates';
 import type { ToastPayload } from './toast';
 import type { TextPredictionSettings } from './text-prediction';
 import type { GeminiNavigatePayload, GeminiReadyPayload, TabsState, TabShortcutPayload } from './tabs';
+import type { HotkeyCaptureResult } from './hotkey-capture';
 
 /**
  * Electron API exposed to renderer process via contextBridge.
@@ -145,6 +146,10 @@ export interface ElectronAPI {
 
     /** Listen for hotkey accelerator changes. Returns unsubscribe function. */
     onHotkeyAcceleratorsChanged: (callback: (accelerators: HotkeyAccelerators) => void) => () => void;
+
+    captureNextHotkey: () => Promise<HotkeyCaptureResult>;
+
+    cancelHotkeyCapture: () => void;
 
     // =========================================================================
     // Always On Top API

--- a/src/shared/utils/acceleratorUtils.ts
+++ b/src/shared/utils/acceleratorUtils.ts
@@ -179,6 +179,133 @@ export interface ParsedAccelerator {
     key: string;
 }
 
+export interface KeyInput {
+    ctrlKey?: boolean;
+    metaKey?: boolean;
+    altKey?: boolean;
+    shiftKey?: boolean;
+    key: string;
+    code: string;
+}
+
+const MODIFIER_KEYS = new Set(['Control', 'Meta', 'Alt', 'Shift', 'CapsLock', 'NumLock', 'ScrollLock']);
+
+function resolveAcceleratorKey(input: Pick<KeyInput, 'key' | 'code'>): string | null {
+    if (MODIFIER_KEYS.has(input.key)) {
+        return null;
+    }
+
+    if (input.code.startsWith('Key')) {
+        return input.code.slice(3);
+    }
+    if (input.code.startsWith('Digit')) {
+        return input.code.slice(5);
+    }
+    if (input.code.startsWith('Numpad')) {
+        const numKey = input.code.slice(6);
+        return /^\d$/.test(numKey) ? `num${numKey}` : `num${numKey.toLowerCase()}`;
+    }
+    if (input.code === 'Space') {
+        return 'Space';
+    }
+    if (input.code === 'Enter') {
+        return 'Enter';
+    }
+    if (input.code === 'Escape') {
+        return 'Escape';
+    }
+    if (input.code === 'Tab') {
+        return 'Tab';
+    }
+    if (input.code === 'Backspace') {
+        return 'Backspace';
+    }
+    if (input.code === 'Delete') {
+        return 'Delete';
+    }
+    if (input.code === 'Insert') {
+        return 'Insert';
+    }
+    if (input.code.startsWith('Arrow')) {
+        return input.code.slice(5);
+    }
+    if (input.code.startsWith('F') && /^F\d{1,2}$/.test(input.code)) {
+        return input.code;
+    }
+    if (input.code === 'Home') {
+        return 'Home';
+    }
+    if (input.code === 'End') {
+        return 'End';
+    }
+    if (input.code === 'PageUp') {
+        return 'PageUp';
+    }
+    if (input.code === 'PageDown') {
+        return 'PageDown';
+    }
+    if (input.code === 'Backquote') {
+        return '`';
+    }
+    if (input.code === 'Minus') {
+        return '-';
+    }
+    if (input.code === 'Equal') {
+        return '=';
+    }
+    if (input.code === 'BracketLeft') {
+        return '[';
+    }
+    if (input.code === 'BracketRight') {
+        return ']';
+    }
+    if (input.code === 'Backslash') {
+        return '\\';
+    }
+    if (input.code === 'Semicolon') {
+        return ';';
+    }
+    if (input.code === 'Quote') {
+        return "'";
+    }
+    if (input.code === 'Comma') {
+        return ',';
+    }
+    if (input.code === 'Period') {
+        return '.';
+    }
+    if (input.code === 'Slash') {
+        return '/';
+    }
+
+    return input.key.length === 1 ? input.key.toUpperCase() : input.key || null;
+}
+
+export function acceleratorFromKeyInput(input: KeyInput): string | null {
+    if (!input.ctrlKey && !input.metaKey && !input.altKey && !input.shiftKey) {
+        return null;
+    }
+
+    const key = resolveAcceleratorKey(input);
+    if (!key) {
+        return null;
+    }
+
+    const parts: string[] = [];
+    if (input.ctrlKey || input.metaKey) {
+        parts.push('CommandOrControl');
+    }
+    if (input.altKey) {
+        parts.push('Alt');
+    }
+    if (input.shiftKey) {
+        parts.push('Shift');
+    }
+
+    parts.push(key);
+    return parts.join('+');
+}
+
 /**
  * Parse an accelerator string into its component parts.
  *
@@ -269,97 +396,7 @@ export function isValidAccelerator(accelerator: string): boolean {
  * keyEventToAccelerator(event) // 'CommandOrControl+Shift+T'
  */
 export function keyEventToAccelerator(event: KeyboardEvent): string {
-    const parts: string[] = [];
-
-    // Modifiers (use CommandOrControl for cross-platform)
-    if (event.ctrlKey || event.metaKey) {
-        parts.push('CommandOrControl');
-    }
-    if (event.altKey) {
-        parts.push('Alt');
-    }
-    if (event.shiftKey) {
-        parts.push('Shift');
-    }
-
-    // Get the main key
-    let key = '';
-
-    // Handle special keys
-    if (event.code.startsWith('Key')) {
-        // KeyA -> A
-        key = event.code.slice(3);
-    } else if (event.code.startsWith('Digit')) {
-        // Digit1 -> 1
-        key = event.code.slice(5);
-    } else if (event.code.startsWith('Numpad')) {
-        // Numpad0 -> num0
-        const numKey = event.code.slice(6);
-        if (/^\d$/.test(numKey)) {
-            key = `num${numKey}`;
-        } else {
-            key = `num${numKey.toLowerCase()}`;
-        }
-    } else if (event.code === 'Space') {
-        key = 'Space';
-    } else if (event.code === 'Enter') {
-        key = 'Enter';
-    } else if (event.code === 'Escape') {
-        key = 'Escape';
-    } else if (event.code === 'Tab') {
-        key = 'Tab';
-    } else if (event.code === 'Backspace') {
-        key = 'Backspace';
-    } else if (event.code === 'Delete') {
-        key = 'Delete';
-    } else if (event.code === 'Insert') {
-        key = 'Insert';
-    } else if (event.code.startsWith('Arrow')) {
-        // ArrowUp -> Up
-        key = event.code.slice(5);
-    } else if (event.code.startsWith('F') && /^F\d{1,2}$/.test(event.code)) {
-        // F1-F24
-        key = event.code;
-    } else if (event.code === 'Home') {
-        key = 'Home';
-    } else if (event.code === 'End') {
-        key = 'End';
-    } else if (event.code === 'PageUp') {
-        key = 'PageUp';
-    } else if (event.code === 'PageDown') {
-        key = 'PageDown';
-    } else if (event.code === 'Backquote') {
-        key = '`';
-    } else if (event.code === 'Minus') {
-        key = '-';
-    } else if (event.code === 'Equal') {
-        key = '=';
-    } else if (event.code === 'BracketLeft') {
-        key = '[';
-    } else if (event.code === 'BracketRight') {
-        key = ']';
-    } else if (event.code === 'Backslash') {
-        key = '\\';
-    } else if (event.code === 'Semicolon') {
-        key = ';';
-    } else if (event.code === 'Quote') {
-        key = "'";
-    } else if (event.code === 'Comma') {
-        key = ',';
-    } else if (event.code === 'Period') {
-        key = '.';
-    } else if (event.code === 'Slash') {
-        key = '/';
-    } else {
-        // Fallback: use the key value
-        key = event.key.length === 1 ? event.key.toUpperCase() : event.key;
-    }
-
-    if (key) {
-        parts.push(key);
-    }
-
-    return parts.join('+');
+    return acceleratorFromKeyInput(event) ?? '';
 }
 
 /**

--- a/tests/e2e/AGENTS.md
+++ b/tests/e2e/AGENTS.md
@@ -32,6 +32,8 @@ Use page objects from `tests/e2e/pages/`.
 Use `beforeEach` with `waitForAppReady()` and `afterEach` with `ensureSingleWindow()` to preserve isolation.
 Group specs by feature behavior, not by helper implementation detail.
 
+For hotkey customization flows, keep E2E focused on the user-visible recorder UX, rendered accelerator text, and high-level registration state. Leave native Windows system-menu suppression to unit/integration coverage unless the host environment is a stable Windows automation target.
+
 ## Canonical Examples
 
 - `tests/e2e/theme.spec.ts`

--- a/tests/e2e/helpers/hotkeyHelpers.ts
+++ b/tests/e2e/helpers/hotkeyHelpers.ts
@@ -11,7 +11,7 @@
 
 import { browser } from '@wdio/globals';
 import type { E2EPlatform } from './platform';
-import { DEFAULT_ACCELERATORS } from '../../../src/shared/types/hotkeys';
+import { DEFAULT_ACCELERATORS, type HotkeyId } from '../../../src/shared/types/hotkeys';
 
 /**
  * Hotkey definition for cross-platform testing.
@@ -82,6 +82,13 @@ const HOTKEY_ID_MAP: Record<keyof typeof REGISTERED_HOTKEYS, string> = {
     VOICE_CHAT: 'voiceChat',
 };
 
+export interface ConfiguredHotkeyRegistration {
+    accelerator: string | null;
+    hotkeyId: HotkeyId;
+    platform: NodeJS.Platform;
+    registered: boolean;
+}
+
 /**
  * Gets the expected accelerator string for the current platform.
  * Electron uses 'CommandOrControl' which maps to Ctrl on Windows/Linux and Cmd on macOS.
@@ -115,6 +122,25 @@ export async function isHotkeyRegistered(accelerator: string): Promise<boolean> 
         (electron: typeof import('electron'), acc: string) => electron.globalShortcut.isRegistered(acc),
         accelerator
     );
+}
+
+export async function getConfiguredHotkeyRegistration(
+    hotkeyId: keyof typeof REGISTERED_HOTKEYS
+): Promise<ConfiguredHotkeyRegistration> {
+    const internalHotkeyId = HOTKEY_ID_MAP[hotkeyId] as HotkeyId;
+
+    return browser.electron.execute((electron: typeof import('electron'), resolvedHotkeyId: HotkeyId) => {
+        const appContext = (global as { appContext?: { hotkeyManager?: { getAccelerator: (id: HotkeyId) => string } } })
+            .appContext;
+        const accelerator = appContext?.hotkeyManager?.getAccelerator(resolvedHotkeyId) ?? null;
+
+        return {
+            accelerator,
+            hotkeyId: resolvedHotkeyId,
+            platform: process.platform,
+            registered: accelerator ? electron.globalShortcut.isRegistered(accelerator) : false,
+        };
+    }, internalHotkeyId);
 }
 
 export async function waitForHotkeyRegistered(

--- a/tests/e2e/hotkey-configuration.e2e.test.ts
+++ b/tests/e2e/hotkey-configuration.e2e.test.ts
@@ -20,6 +20,7 @@ import {
 } from './helpers/optionsWindowActions';
 import { waitForUIState, waitForAnimationSettle, waitForWindowCount } from './helpers/waitUtilities';
 import { OptionsPage } from './pages/OptionsPage';
+import { isWindows } from './helpers/platform';
 
 // Create page object instance for use in tests
 const optionsPage = new OptionsPage();
@@ -269,6 +270,31 @@ describe('Hotkey Configuration E2E', () => {
             // Should have 4 keycaps
             const keycaps = await acceleratorDisplay.$$('kbd.keycap');
             expect(keycaps.length).toBe(4);
+        });
+
+        it('should record Alt+Space for quick chat on Windows via native capture', async () => {
+            if (!(await isWindows())) {
+                return;
+            }
+
+            try {
+                await optionsPage.recordAccelerator('quickChat', ['Alt', 'Space']);
+
+                const acceleratorText = await optionsPage.getCurrentAccelerator('quickChat');
+                expect(acceleratorText).toContain('Alt');
+                expect(acceleratorText).toContain('␣');
+
+                const savedAccelerator = await wdioBrowser.electron.execute((_electron: typeof import('electron')) => {
+                    return (global as { appContext?: any }).appContext?.hotkeyManager?.getAccelerator('quickChat');
+                });
+
+                expect(savedAccelerator).toBe('Alt+Space');
+            } finally {
+                await wdioBrowser.execute(async () => {
+                    const api = (window as any).electronAPI;
+                    await api.setHotkeyAccelerator('quickChat', 'CommandOrControl+Shift+Alt+Space');
+                });
+            }
         });
     });
 

--- a/tests/e2e/hotkeys.spec.ts
+++ b/tests/e2e/hotkeys.spec.ts
@@ -12,6 +12,8 @@ import {
     waitForWindowTransition,
 } from './helpers/workflows';
 import { waitForUIState } from './helpers/waitUtilities';
+import { DEFAULT_ACCELERATORS } from '../../src/shared/types/hotkeys';
+import { getConfiguredHotkeyRegistration } from './helpers/hotkeyHelpers';
 
 interface HotkeyTestConfig {
     id: string;
@@ -109,6 +111,13 @@ describe('Hotkeys', () => {
             await waitForAppReady();
         });
 
+        afterEach(async () => {
+            await browser.execute(async (defaultAccelerator) => {
+                const api = (window as any).electronAPI;
+                await api.setHotkeyAccelerator('quickChat', defaultAccelerator);
+            }, DEFAULT_ACCELERATORS.quickChat);
+        });
+
         it('should successfully register default hotkeys on startup', async () => {
             if (await isLinux()) {
                 console.log('[SKIPPED] Global hotkey registration test skipped on Linux.');
@@ -159,6 +168,23 @@ describe('Hotkeys', () => {
 
             expect(registrationStatus.quickChat).toBe(true);
             expect(registrationStatus.peekAndHide).toBe(true);
+        });
+
+        it('should register a configured Alt+Space quick chat accelerator on Windows', async () => {
+            if ((await getPlatform()) !== 'windows') {
+                return;
+            }
+
+            await browser.execute(async () => {
+                const api = (window as any).electronAPI;
+                await api.setHotkeyAccelerator('quickChat', 'Alt+Space');
+            });
+
+            const registration = await getConfiguredHotkeyRegistration('QUICK_CHAT');
+
+            expect(registration.platform).toBe('win32');
+            expect(registration.accelerator).toBe('Alt+Space');
+            expect(registration.registered).toBe(true);
         });
     });
 

--- a/tests/e2e/pages/OptionsPage.ts
+++ b/tests/e2e/pages/OptionsPage.ts
@@ -15,6 +15,7 @@ import { browser } from '@wdio/globals';
 import { navigateToOptionsTab, closeOptionsWindow, waitForOptionsWindow } from '../helpers/optionsWindowActions';
 import { E2E_TIMING } from '../helpers/e2eConstants';
 import { waitForIPCRoundTrip, waitForAnimationSettle } from '../helpers/waitUtilities';
+import type { HotkeyId } from '../../../src/shared/types/hotkeys';
 
 type OPElement = {
     getAttribute(attr: string): Promise<string | null>;
@@ -375,6 +376,26 @@ export class OptionsPage extends BasePage {
             },
             async () => await this.isRecordingModeActive(hotkeyId)
         );
+    }
+
+    async waitForRecordingModeToExit(hotkeyId: string, timeout = 5000): Promise<void> {
+        await opBrowser.waitUntil(async () => !(await this.isRecordingModeActive(hotkeyId)), {
+            timeout,
+            timeoutMsg: `Recording mode did not exit for hotkey ${hotkeyId}`,
+        });
+    }
+
+    async recordAccelerator(hotkeyId: HotkeyId, keys: string[]): Promise<void> {
+        await this.clickAcceleratorInput(hotkeyId);
+        await waitForIPCRoundTrip(
+            async () => {
+                await browser.keys(keys);
+            },
+            {
+                verification: async () => !(await this.isRecordingModeActive(hotkeyId)),
+            }
+        );
+        await this.waitForRecordingModeToExit(hotkeyId);
     }
 
     /**

--- a/tests/helpers/mocks/main/managers.ts
+++ b/tests/helpers/mocks/main/managers.ts
@@ -122,6 +122,7 @@ export interface MockHotkeyManager {
     setAccelerator: ReturnType<typeof vi.fn>;
     updateAllAccelerators: ReturnType<typeof vi.fn>;
     getFullSettings: ReturnType<typeof vi.fn>;
+    ownsRegisteredGlobalAccelerator: ReturnType<typeof vi.fn>;
     executeHotkeyAction: ReturnType<typeof vi.fn>;
     getGlobalHotkeyActions: ReturnType<typeof vi.fn>;
     getApplicationHotkeyActions: ReturnType<typeof vi.fn>;
@@ -371,6 +372,7 @@ export function createMockHotkeyManager(overrides?: Partial<Omit<MockHotkeyManag
         setAccelerator: vi.fn().mockReturnValue(true),
         updateAllAccelerators: vi.fn(),
         getFullSettings: vi.fn().mockReturnValue({}),
+        ownsRegisteredGlobalAccelerator: vi.fn().mockReturnValue(false),
         executeHotkeyAction: vi.fn(),
         getGlobalHotkeyActions: vi.fn().mockReturnValue([]),
         getApplicationHotkeyActions: vi.fn().mockReturnValue([]),

--- a/tests/helpers/mocks/renderer/electronAPI.ts
+++ b/tests/helpers/mocks/renderer/electronAPI.ts
@@ -125,6 +125,8 @@ export function createMockElectronAPI(overrides: MockElectronAPIOverrides = {}):
         }),
         setHotkeyAccelerator: vi.fn(),
         onHotkeyAcceleratorsChanged: vi.fn().mockReturnValue(defaultUnsubscribe),
+        captureNextHotkey: vi.fn().mockResolvedValue({ status: 'cancelled', accelerator: null }),
+        cancelHotkeyCapture: vi.fn(),
 
         // =========================================================================
         // Always On Top API

--- a/tests/integration/AGENTS.md
+++ b/tests/integration/AGENTS.md
@@ -17,6 +17,8 @@ Primary files and folders:
 Choose integration tests over unit tests when behavior crosses process or window boundaries, but you do not need the full end-user workflow depth of `tests/e2e/`.
 Choose coordinated tests when mocked Electron/Vitest coverage is enough; choose E2E when you must validate the real user-facing workflow from UI action through outcome.
 
+For configurable hotkeys, prefer integration tests for renderer → preload → main persistence and registration assertions (for example: setting an accelerator through `window.electronAPI`, then checking `HotkeyManager`, `globalShortcut`, and persisted store values from the main process).
+
 ## Canonical Patterns
 
 - Reuse helpers from `tests/integration/helpers/` before adding spec-local setup code.

--- a/tests/integration/hotkeys.integration.test.ts
+++ b/tests/integration/hotkeys.integration.test.ts
@@ -1,6 +1,8 @@
 import { browser, expect } from '@wdio/globals';
 import { DEFAULT_ACCELERATORS } from '../../src/shared/types/hotkeys';
 
+const QUICK_CHAT_ALT_SPACE = 'Alt+Space';
+
 describe('Global Hotkeys Integration', () => {
     before(async () => {
         await browser.waitUntil(async () => (await browser.getWindowHandles()).length > 0);
@@ -80,6 +82,41 @@ describe('Global Hotkeys Integration', () => {
         // The test mock or real implementation might return the raw string or parsed
         // Based on unit tests, it returns the raw 'CommandOrControl+...' string matching input
         expect(savedAccelerator).toBe(newAccelerator);
+    });
+
+    it('should persist and register Alt+Space for quick chat on Windows', async () => {
+        try {
+            await browser.execute(async (accelerator) => {
+                const api = (window as any).electronAPI;
+                await api.setHotkeyAccelerator('quickChat', accelerator);
+            }, QUICK_CHAT_ALT_SPACE);
+
+            const quickChatState = await browser.electron.execute((electron, altSpaceAccelerator) => {
+                const appContext = (global as any).appContext;
+                const accelerator = appContext.hotkeyManager.getAccelerator('quickChat');
+                const persistedAccelerator = appContext.ipcManager.store.get('acceleratorQuickChat');
+                const platform = process.platform;
+
+                return {
+                    accelerator,
+                    persistedAccelerator,
+                    platform,
+                    registered: platform === 'win32' ? electron.globalShortcut.isRegistered(altSpaceAccelerator) : null,
+                };
+            }, QUICK_CHAT_ALT_SPACE);
+
+            expect(quickChatState.accelerator).toBe(QUICK_CHAT_ALT_SPACE);
+            expect(quickChatState.persistedAccelerator).toBe(QUICK_CHAT_ALT_SPACE);
+
+            if (quickChatState.platform === 'win32') {
+                expect(quickChatState.registered).toBe(true);
+            }
+        } finally {
+            await browser.execute(async (accelerator) => {
+                const api = (window as any).electronAPI;
+                await api.setHotkeyAccelerator('quickChat', accelerator);
+            }, DEFAULT_ACCELERATORS.quickChat);
+        }
     });
 
     describe('Cross-Platform Behavior', () => {

--- a/tests/unit/main/hotkeyManager.test.ts
+++ b/tests/unit/main/hotkeyManager.test.ts
@@ -306,6 +306,26 @@ describe('HotkeyManager', () => {
         });
     });
 
+    describe('ownsRegisteredGlobalAccelerator', () => {
+        beforeEach(() => {
+            mockGlobalShortcut.register.mockReturnValue(true);
+        });
+
+        it('returns true when a global hotkey is actively registered with Alt+Space', () => {
+            hotkeyManager.setAccelerator('quickChat', 'Alt+Space');
+            hotkeyManager.registerShortcuts();
+
+            expect(hotkeyManager.ownsRegisteredGlobalAccelerator('Alt+Space')).toBe(true);
+        });
+
+        it('returns false when Alt+Space is configured but disabled', () => {
+            hotkeyManager.setAccelerator('quickChat', 'Alt+Space');
+            hotkeyManager.setIndividualEnabled('quickChat', false);
+
+            expect(hotkeyManager.ownsRegisteredGlobalAccelerator('Alt+Space')).toBe(false);
+        });
+    });
+
     describe('getFullSettings', () => {
         it('should return combined enabled states and accelerators', () => {
             expect(hotkeyManager.getFullSettings()).toEqual({

--- a/tests/unit/main/ipc/HotkeyIpcHandler.test.ts
+++ b/tests/unit/main/ipc/HotkeyIpcHandler.test.ts
@@ -80,6 +80,10 @@ describe('HotkeyIpcHandler', () => {
         setIndividualEnabled: ReturnType<typeof vi.fn>;
         setAccelerator: ReturnType<typeof vi.fn>;
     };
+    let mockWindowsHotkeyCaptureManager: {
+        beginCapture: ReturnType<typeof vi.fn>;
+        cancelCapture: ReturnType<typeof vi.fn>;
+    };
 
     beforeEach(() => {
         vi.clearAllMocks();
@@ -94,12 +98,20 @@ describe('HotkeyIpcHandler', () => {
             setIndividualEnabled: vi.fn(),
             setAccelerator: vi.fn(),
         };
+        mockWindowsHotkeyCaptureManager = {
+            beginCapture: vi.fn().mockResolvedValue({
+                status: 'captured',
+                accelerator: 'Alt+Space',
+            }),
+            cancelCapture: vi.fn(),
+        };
 
         mockDeps = {
             store: mockStore,
             logger: mockLogger,
             windowManager: createMockWindowManager(),
             hotkeyManager: mockHotkeyManager,
+            windowsHotkeyCaptureManager: mockWindowsHotkeyCaptureManager,
         } as unknown as IpcHandlerDependencies;
 
         handler = new HotkeyIpcHandler(mockDeps);
@@ -152,6 +164,23 @@ describe('HotkeyIpcHandler', () => {
                 expect.any(Function)
             );
             expect(mockIpcMain._handlers.has(IPC_CHANNELS.HOTKEYS_FULL_SETTINGS_GET)).toBe(true);
+        });
+
+        it('registers hotkeys:capture:accelerator handler', () => {
+            handler.register();
+
+            expect(mockIpcMain.handle).toHaveBeenCalledWith(
+                IPC_CHANNELS.HOTKEYS_CAPTURE_ACCELERATOR,
+                expect.any(Function)
+            );
+            expect(mockIpcMain._handlers.has(IPC_CHANNELS.HOTKEYS_CAPTURE_ACCELERATOR)).toBe(true);
+        });
+
+        it('registers hotkeys:capture:cancel listener', () => {
+            handler.register();
+
+            expect(mockIpcMain.on).toHaveBeenCalledWith(IPC_CHANNELS.HOTKEYS_CAPTURE_CANCEL, expect.any(Function));
+            expect(mockIpcMain._listeners.has(IPC_CHANNELS.HOTKEYS_CAPTURE_CANCEL)).toBe(true);
         });
     });
 
@@ -515,6 +544,30 @@ describe('HotkeyIpcHandler', () => {
         });
     });
 
+    describe('hotkey capture handlers', () => {
+        beforeEach(() => {
+            handler.register();
+        });
+
+        it('routes capture requests to windowsHotkeyCaptureManager using sender window id', async () => {
+            const invokeHandler = mockIpcMain._handlers.get(IPC_CHANNELS.HOTKEYS_CAPTURE_ACCELERATOR);
+            const result = await invokeHandler!({ sender: mockBrowserWindow._mockWebContents });
+
+            expect(mockWindowsHotkeyCaptureManager.beginCapture).toHaveBeenCalledWith(1);
+            expect(result).toEqual({
+                status: 'captured',
+                accelerator: 'Alt+Space',
+            });
+        });
+
+        it('routes capture cancellation to windowsHotkeyCaptureManager using sender window id', () => {
+            const listener = mockIpcMain._listeners.get(IPC_CHANNELS.HOTKEYS_CAPTURE_CANCEL);
+            listener!({ sender: mockBrowserWindow._mockWebContents });
+
+            expect(mockWindowsHotkeyCaptureManager.cancelCapture).toHaveBeenCalledWith(1);
+        });
+    });
+
     describe('broadcast skips destroyed windows', () => {
         beforeEach(() => {
             handler.register();
@@ -664,6 +717,8 @@ describe('HotkeyIpcHandler', () => {
 
             handler.unregister();
 
+            expect(mockIpcMain.removeHandler).toHaveBeenCalledWith(IPC_CHANNELS.HOTKEYS_CAPTURE_ACCELERATOR);
+            expect(mockIpcMain.removeAllListeners).toHaveBeenCalledWith(IPC_CHANNELS.HOTKEYS_CAPTURE_CANCEL);
             expect(mockIpcMain.removeHandler).toHaveBeenCalledWith(IPC_CHANNELS.PLATFORM_HOTKEY_STATUS_GET);
         });
     });

--- a/tests/unit/main/windowsHotkeyCaptureManager.test.ts
+++ b/tests/unit/main/windowsHotkeyCaptureManager.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createMockHotkeyManager } from '../../helpers/mocks';
+import { WindowsHotkeyCaptureManager } from '../../../src/main/managers/windowsHotkeyCaptureManager';
+
+const createMockWindow = () => {
+    const webContentsListeners = new Map<string, (...args: unknown[]) => void>();
+    const windowListeners = new Map<string, (...args: unknown[]) => void>();
+
+    const win = {
+        id: 7,
+        isDestroyed: vi.fn().mockReturnValue(false),
+        getPosition: vi.fn().mockReturnValue([100, 101]),
+        webContents: {
+            on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+                webContentsListeners.set(event, handler);
+            }),
+        },
+        on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+            windowListeners.set(event, handler);
+        }),
+    };
+
+    return {
+        win,
+        getWebContentsListener: (event: string) => webContentsListeners.get(event),
+        getWindowListener: (event: string) => windowListeners.get(event),
+    };
+};
+
+describe('WindowsHotkeyCaptureManager', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('attaches before-input-event and system-context-menu listeners on Windows', () => {
+        const hotkeyManager = createMockHotkeyManager();
+        const manager = new WindowsHotkeyCaptureManager(hotkeyManager as never, 'win32');
+        const { win } = createMockWindow();
+
+        manager.attachWindow(win as never);
+
+        expect(win.webContents.on).toHaveBeenCalledWith('before-input-event', expect.any(Function));
+        expect(win.on).toHaveBeenCalledWith('system-context-menu', expect.any(Function));
+        expect(win.on).toHaveBeenCalledWith('closed', expect.any(Function));
+    });
+
+    it('captures Alt+Space from keyboard corroboration plus system-context-menu', async () => {
+        const hotkeyManager = createMockHotkeyManager();
+        const manager = new WindowsHotkeyCaptureManager(hotkeyManager as never, 'win32');
+        const { win, getWebContentsListener, getWindowListener } = createMockWindow();
+        manager.attachWindow(win as never);
+
+        const capturePromise = manager.beginCapture(win.id);
+        const beforeInputEvent = getWebContentsListener('before-input-event');
+        const systemContextMenu = getWindowListener('system-context-menu');
+        const preventDefault = vi.fn();
+
+        beforeInputEvent?.(
+            { preventDefault: vi.fn() },
+            {
+                type: 'keyDown',
+                key: 'Alt',
+                code: 'AltLeft',
+                alt: true,
+                control: false,
+                shift: false,
+                meta: false,
+                isAutoRepeat: false,
+            }
+        );
+
+        systemContextMenu?.({ preventDefault }, { x: 100, y: 100 });
+
+        await expect(capturePromise).resolves.toEqual({
+            status: 'captured',
+            accelerator: 'Alt+Space',
+        });
+        expect(preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not suppress the Windows system menu without keyboard corroboration during global Alt+Space registration', () => {
+        const hotkeyManager = createMockHotkeyManager({
+            ownsRegisteredGlobalAccelerator: vi.fn().mockReturnValue(true),
+        });
+        const manager = new WindowsHotkeyCaptureManager(hotkeyManager as never, 'win32');
+        const { win, getWindowListener } = createMockWindow();
+        manager.attachWindow(win as never);
+
+        const preventDefault = vi.fn();
+        getWindowListener('system-context-menu')?.({ preventDefault }, { x: 100, y: 100 });
+
+        expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('does not suppress mouse-triggered system menus just because Alt+Space is registered', () => {
+        const hotkeyManager = createMockHotkeyManager({
+            ownsRegisteredGlobalAccelerator: vi.fn().mockReturnValue(true),
+        });
+        const manager = new WindowsHotkeyCaptureManager(hotkeyManager as never, 'win32');
+        const { win, getWindowListener } = createMockWindow();
+        manager.attachWindow(win as never);
+
+        const preventDefault = vi.fn();
+        getWindowListener('system-context-menu')?.({ preventDefault }, { x: 180, y: 220 });
+
+        expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('suppresses keyboard-triggered system menu when Alt+Space is registered globally', () => {
+        const hotkeyManager = createMockHotkeyManager({
+            ownsRegisteredGlobalAccelerator: vi.fn().mockReturnValue(true),
+        });
+        const manager = new WindowsHotkeyCaptureManager(hotkeyManager as never, 'win32');
+        const { win, getWebContentsListener, getWindowListener } = createMockWindow();
+        manager.attachWindow(win as never);
+
+        getWebContentsListener('before-input-event')?.(
+            { preventDefault: vi.fn() },
+            {
+                type: 'keyDown',
+                key: 'Alt',
+                code: 'AltLeft',
+                alt: true,
+                control: false,
+                shift: false,
+                meta: false,
+                isAutoRepeat: false,
+            }
+        );
+
+        const preventDefault = vi.fn();
+        getWindowListener('system-context-menu')?.({ preventDefault }, { x: 100, y: 100 });
+
+        expect(preventDefault).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/unit/preload/preload.test.ts
+++ b/tests/unit/preload/preload.test.ts
@@ -308,6 +308,27 @@ describe('Preload Script', () => {
         });
     });
 
+    describe('Hotkey capture API', () => {
+        it('captureNextHotkey should invoke IPC handler', async () => {
+            const mockResult = {
+                status: 'captured',
+                accelerator: 'Alt+Space',
+            };
+            (ipcRendererMock.invoke as any).mockResolvedValue(mockResult);
+
+            const result = await exposedAPI.captureNextHotkey();
+
+            expect(ipcRendererMock.invoke).toHaveBeenCalledWith('hotkeys:capture:accelerator');
+            expect(result).toEqual(mockResult);
+        });
+
+        it('cancelHotkeyCapture should send IPC message', () => {
+            exposedAPI.cancelHotkeyCapture();
+
+            expect(ipcRendererMock.send).toHaveBeenCalledWith('hotkeys:capture:cancel');
+        });
+    });
+
     describe('D-Bus activation signal API gating', () => {
         it('exposes getDbusActivationSignalStats when NODE_ENV=test', () => {
             // In test mode (which is the current environment), the API should be exposed

--- a/tests/unit/renderer/components/options/HotkeyAcceleratorInput.test.tsx
+++ b/tests/unit/renderer/components/options/HotkeyAcceleratorInput.test.tsx
@@ -5,6 +5,7 @@
  * keycap display, and reset functionality.
  */
 
+import React, { StrictMode } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { HotkeyAcceleratorInput } from '../../../../../src/renderer/components/options/HotkeyAcceleratorInput';
@@ -37,7 +38,7 @@ describe('HotkeyAcceleratorInput', () => {
         vi.clearAllMocks();
         originalElectronAPI = window.electronAPI;
         // Use shared factory with default platform
-        setupMockElectronAPI({ platform: 'win32' });
+        setupMockElectronAPI({ platform: 'linux' });
     });
 
     afterEach(() => {
@@ -121,6 +122,10 @@ describe('HotkeyAcceleratorInput', () => {
         });
 
         it('should capture key combination and update accelerator', async () => {
+            setupMockElectronAPI({
+                platform: 'linux',
+            });
+
             render(<HotkeyAcceleratorInput {...defaultProps} />);
 
             const input = screen.getByRole('button', { name: /keyboard shortcut/i });
@@ -139,6 +144,88 @@ describe('HotkeyAcceleratorInput', () => {
             });
 
             expect(mockOnChange).toHaveBeenCalledWith('alwaysOnTop', 'CommandOrControl+Shift+F');
+        });
+
+        it('should use native Windows capture and accept Alt+Space', async () => {
+            const captureNextHotkey = vi.fn().mockResolvedValue({
+                status: 'captured',
+                accelerator: 'Alt+Space',
+            });
+
+            setupMockElectronAPI({
+                platform: 'win32',
+                captureNextHotkey,
+            });
+
+            render(<HotkeyAcceleratorInput {...defaultProps} />);
+
+            fireEvent.click(screen.getByRole('button', { name: /keyboard shortcut/i }));
+
+            await waitFor(() => {
+                expect(captureNextHotkey).toHaveBeenCalledTimes(1);
+            });
+
+            await waitFor(() => {
+                expect(mockOnChange).toHaveBeenCalledWith('alwaysOnTop', 'Alt+Space');
+            });
+        });
+
+        it('should still apply Windows capture results after StrictMode remount', async () => {
+            let resolveCapture: ((result: { status: 'captured'; accelerator: string }) => void) | undefined;
+            const captureNextHotkey = vi.fn().mockImplementation(
+                () =>
+                    new Promise((resolve) => {
+                        resolveCapture = resolve;
+                    })
+            );
+
+            setupMockElectronAPI({
+                platform: 'win32',
+                captureNextHotkey,
+                cancelHotkeyCapture: vi.fn(),
+            });
+
+            render(
+                <StrictMode>
+                    <HotkeyAcceleratorInput {...defaultProps} />
+                </StrictMode>
+            );
+
+            fireEvent.click(screen.getByRole('button', { name: /keyboard shortcut/i }));
+
+            await waitFor(() => {
+                expect(captureNextHotkey).toHaveBeenCalledTimes(1);
+            });
+
+            resolveCapture?.({ status: 'captured', accelerator: 'Alt+Space' });
+
+            await waitFor(() => {
+                expect(mockOnChange).toHaveBeenCalledWith('alwaysOnTop', 'Alt+Space');
+            });
+        });
+
+        it('should exit recording when native Windows capture rejects', async () => {
+            const captureNextHotkey = vi.fn().mockRejectedValue(new Error('IPC failure'));
+
+            setupMockElectronAPI({
+                platform: 'win32',
+                captureNextHotkey,
+                cancelHotkeyCapture: vi.fn(),
+            });
+
+            render(<HotkeyAcceleratorInput {...defaultProps} />);
+
+            fireEvent.click(screen.getByRole('button', { name: /keyboard shortcut/i }));
+
+            await waitFor(() => {
+                expect(captureNextHotkey).toHaveBeenCalledTimes(1);
+            });
+
+            await waitFor(() => {
+                expect(screen.queryByText('Press keys...')).not.toBeInTheDocument();
+            });
+
+            expect(mockOnChange).not.toHaveBeenCalled();
         });
 
         it('should cancel recording on Escape key', async () => {
@@ -160,6 +247,14 @@ describe('HotkeyAcceleratorInput', () => {
         });
 
         it('should cancel recording on blur', async () => {
+            const cancelHotkeyCapture = vi.fn();
+
+            setupMockElectronAPI({
+                platform: 'win32',
+                captureNextHotkey: vi.fn().mockImplementation(() => new Promise(() => {})),
+                cancelHotkeyCapture,
+            });
+
             render(<HotkeyAcceleratorInput {...defaultProps} />);
 
             const input = screen.getByRole('button', { name: /keyboard shortcut/i });
@@ -174,6 +269,8 @@ describe('HotkeyAcceleratorInput', () => {
             await waitFor(() => {
                 expect(screen.queryByText('Press keys...')).not.toBeInTheDocument();
             });
+
+            expect(cancelHotkeyCapture).toHaveBeenCalledTimes(1);
         });
 
         it('should not enter recording mode when disabled', () => {

--- a/tests/unit/shared/acceleratorUtils.test.ts
+++ b/tests/unit/shared/acceleratorUtils.test.ts
@@ -11,6 +11,7 @@ import {
     parseAccelerator,
     isValidAccelerator,
     keyEventToAccelerator,
+    acceleratorFromKeyInput,
     formatAcceleratorForDisplay,
     normalizeAccelerator,
 } from '../../../src/shared/utils/acceleratorUtils';
@@ -259,6 +260,37 @@ describe('acceleratorUtils', () => {
                 ctrlKey: true,
             });
             expect(keyEventToAccelerator(endEvent)).toBe('CommandOrControl+End');
+        });
+    });
+
+    describe('acceleratorFromKeyInput', () => {
+        it('returns Alt+Space for Windows reserved combination input', () => {
+            expect(
+                acceleratorFromKeyInput({
+                    altKey: true,
+                    code: 'Space',
+                    key: ' ',
+                })
+            ).toBe('Alt+Space');
+        });
+
+        it('returns null for modifier-only input', () => {
+            expect(
+                acceleratorFromKeyInput({
+                    altKey: true,
+                    code: 'AltLeft',
+                    key: 'Alt',
+                })
+            ).toBeNull();
+        });
+
+        it('returns null when no modifiers are pressed', () => {
+            expect(
+                acceleratorFromKeyInput({
+                    code: 'KeyA',
+                    key: 'a',
+                })
+            ).toBeNull();
         });
     });
 


### PR DESCRIPTION
## Summary
- add a Windows-only hotkey capture manager so `Alt+Space` can be recorded, persisted, and registered without relying on renderer key events
- wire the new hotkey capture contract through shared types, IPC, preload, renderer, and focused unit/integration/e2e coverage
- tighten follow-up behavior from review by making renderer capture StrictMode-safe and limiting Windows system-menu suppression to keyboard-correlated `Alt+Space`

## Verification
- `npm run test` ✅ (55 files, 650 passed, 4 skipped)
- `npm run test:electron` ✅ (76 files, 1861 passed)
- `npm run lint` ✅
- `npm run build` ✅
- `npm run build:electron` ✅
- `npm run test:integration -- --spec=tests/integration/hotkeys.integration.test.ts` ✅ (17 passing)
- `npm run test:e2e:spec -- --spec=tests/e2e/hotkey-configuration.e2e.test.ts` ⚠️ Linux/Xvfb failure opening Options via `Control+,` (`Options window handle did not appear`), not the new Alt+Space path
- `npm run test:e2e:spec -- --spec=tests/e2e/hotkeys.spec.ts` ⚠️ Linux/Xvfb WebDriver/browser session collapse (`invalid session id`), not a deterministic Alt+Space assertion failure

## Notes
- Oracle review and ultrabrain review were both collected before finalizing.
- Review feedback incorporated before merge:
  - fixed StrictMode/dev capture lifecycle in `HotkeyAcceleratorInput`
  - narrowed `system-context-menu` suppression so mouse-triggered menus are not blocked just because `Alt+Space` is registered
