### PR TITLE
Fix Windows installer packaging: include NSIS sidecars and harden dist:win

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -251,6 +251,7 @@ jobs:
                   const expectedUploadFiles = [
                       `release/${manifest.promotedInstallerName}`,
                       `release/${manifest.promotedBlockmapName}`,
+                      ...(manifest.nsisPackageNames ?? []).map((fileName) => `release/${fileName}`),
                       'release/latest.yml',
                       'release/latest-x64.yml',
                       'release/latest-arm64.yml',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ The project uses **npm** for package management and **Vitest** + **WebdriverIO**
 - `npm run electron:dev` - Start the app in development mode
 - `npm run build` - Full build (TypeScript + Vite)
 - `npm run clean` - Clean build artifacts
+- `npm run dist:win` auto-builds `dist/` and `dist-electron/` if missing before packaging.
 
 ### Linting & Formatting
 

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -40,6 +40,9 @@ const windowsBinaryExclusions = getWindowsBinaryExclusions();
 module.exports = {
     appId: 'com.benwendell.gemini-desktop',
     productName: 'Gemini Desktop',
+    // Windows builds do not need native module rebuild for this app.
+    // Rebuild can fail on Linux-only transitive deps (e.g. dbus-next/usocket).
+    npmRebuild: !isWindowsBuild,
 
     directories: {
         output: 'release',

--- a/scripts/release/lib/windows-release-contract.cjs
+++ b/scripts/release/lib/windows-release-contract.cjs
@@ -47,6 +47,7 @@ function discoverWindowsReleaseFiles(releaseDir, version) {
     const installerName = `Gemini-Desktop-${version}-installer.exe`;
     const blockmapName = `${installerName}.blockmap`;
     const archSpecificInstallers = entries.filter((entry) => /-(x64|arm64)-installer\.exe$/i.test(entry));
+    const nsisPackageNames = entries.filter((entry) => /\.(x64|arm64)\.nsis\.7z$/i.test(entry)).sort();
     const msiArtifacts = entries.filter((entry) => /\.msi$/i.test(entry));
 
     if (archSpecificInstallers.length > 0) {
@@ -73,6 +74,7 @@ function discoverWindowsReleaseFiles(releaseDir, version) {
         ...installerInfo,
         blockmapName,
         blockmapPath,
+        nsisPackageNames,
     };
 }
 
@@ -161,6 +163,7 @@ function prepareWindowsReleaseAssets({ releaseDir, version, githubOutputPath }) 
     const windowsUploadFiles = [
         installerInfo.installerName,
         installerInfo.blockmapName,
+        ...installerInfo.nsisPackageNames,
         ...WINDOWS_METADATA_FILES,
         'checksums-windows.txt',
     ].map((fileName) => toReleaseContractPath(fileName));
@@ -172,6 +175,7 @@ function prepareWindowsReleaseAssets({ releaseDir, version, githubOutputPath }) 
         promotedInstallerSha512: installerInfo.sha512,
         promotedInstallerSize: installerInfo.size,
         promotedBlockmapName: installerInfo.blockmapName,
+        nsisPackageNames: installerInfo.nsisPackageNames,
         metadataFiles: WINDOWS_METADATA_FILES,
         windowsUploadFiles,
     });

--- a/scripts/release/run-windows-dist.cjs
+++ b/scripts/release/run-windows-dist.cjs
@@ -1,8 +1,41 @@
 const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function runNpmScript(scriptName, env) {
+    const result = spawnSync('npm', ['run', scriptName], {
+        stdio: 'inherit',
+        shell: true,
+        env,
+    });
+
+    if (typeof result.status === 'number' && result.status !== 0) {
+        process.exit(result.status);
+    }
+
+    if (result.error) {
+        throw result.error;
+    }
+}
+
+function ensureBuildArtifacts(env) {
+    const requiredPaths = [path.resolve('dist/index.html'), path.resolve('dist-electron/main/main.cjs')];
+
+    const missingArtifacts = requiredPaths.filter((artifactPath) => !fs.existsSync(artifactPath));
+
+    if (missingArtifacts.length === 0) {
+        return;
+    }
+
+    console.log('Missing build artifacts detected for Windows dist. Running build + build:electron first...');
+    runNpmScript('build', env);
+    runNpmScript('build:electron', env);
+}
 
 function runWindowsDist(mode) {
     const env = { ...process.env, BUILD_PLATFORM: 'win32' };
     const args = ['electron-builder', '--win', '--publish', 'never', '--config', 'config/electron-builder.config.cjs'];
+    ensureBuildArtifacts(env);
 
     switch (mode) {
         case 'unified':

--- a/tests/unit/main/release/prepareWindowsReleaseAssets.test.ts
+++ b/tests/unit/main/release/prepareWindowsReleaseAssets.test.ts
@@ -56,6 +56,15 @@ function writeBaseReleaseFiles(
     return { installerName, installerBuffer };
 }
 
+function writeNsisSidecarArchives(releaseDir: string): string[] {
+    const archives = ['Gemini-Desktop-0.12.0.x64.nsis.7z', 'Gemini-Desktop-0.12.0.arm64.nsis.7z'];
+    for (const archive of archives) {
+        fs.writeFileSync(path.join(releaseDir, archive), `${archive}-contents`, 'utf8');
+    }
+
+    return archives;
+}
+
 describe('prepare-windows-release-assets', () => {
     it('accepts exactly one promoted unified installer', () => {
         const { discoverWindowsReleaseFiles } = loadWindowsReleaseContract();
@@ -167,6 +176,32 @@ describe('prepare-windows-release-assets', () => {
         expect(result.windowsUploadFiles).toEqual([
             'release/Gemini-Desktop-0.12.0-installer.exe',
             'release/Gemini-Desktop-0.12.0-installer.exe.blockmap',
+            'release/latest.yml',
+            'release/latest-x64.yml',
+            'release/latest-arm64.yml',
+            'release/x64.yml',
+            'release/arm64.yml',
+            'release/checksums-windows.txt',
+        ]);
+    });
+
+    it('includes NSIS sidecar archives in the upload contract when present', () => {
+        const { prepareWindowsReleaseAssets } = loadWindowsReleaseContract();
+        const releaseDir = makeTempReleaseDir();
+
+        writeBaseReleaseFiles(releaseDir);
+        writeNsisSidecarArchives(releaseDir);
+
+        const result = prepareWindowsReleaseAssets({
+            releaseDir,
+            version: '0.12.0',
+        });
+
+        expect(result.windowsUploadFiles).toEqual([
+            'release/Gemini-Desktop-0.12.0-installer.exe',
+            'release/Gemini-Desktop-0.12.0-installer.exe.blockmap',
+            'release/Gemini-Desktop-0.12.0.arm64.nsis.7z',
+            'release/Gemini-Desktop-0.12.0.x64.nsis.7z',
             'release/latest.yml',
             'release/latest-x64.yml',
             'release/latest-arm64.yml',


### PR DESCRIPTION
## Summary

Fixes Windows release packaging and local Windows build reliability.

This PR addresses the issue where Windows installs could end up with incomplete payloads (including cases where users reported only uninstall artifacts), and fixes local `dist:win` failures on fresh checkouts.

Fixes bwendell/gemini-desktop#274

## What changed

- Included NSIS sidecar payloads (`*.x64.nsis.7z`, `*.arm64.nsis.7z`) in the Windows release upload contract.
- Updated workflow contract validation to account for sidecar payload entries from manifest.
- Added unit coverage to ensure sidecar archives are included when present.
- Set `npmRebuild` to skip native rebuild on Windows packaging (`npmRebuild: !isWindowsBuild`) to avoid rebuilding Linux-only transitive deps (`dbus-next/usocket`) on Windows.
- Hardened `dist:win` script to auto-run `build` + `build:electron` when required artifacts are missing.
- Updated `AGENTS.md` to document `dist:win` auto-build behavior.

## Why

Observed Windows build/install failure modes:
- Local `dist:win` could package without required build artifacts on clean environments.
- Windows packaging attempted to rebuild Linux-only native transitive deps.
- Unified NSIS distribution needed sidecar payload files included in release assets.

## Validation

- Ran focused Windows release/unit tests:
  - `tests/unit/main/release/prepareWindowsReleaseAssets.test.ts`
  - `tests/unit/main/windowsReleaseArtifacts.test.ts`
  - `tests/unit/main/releaseWorkflowAliases.test.ts`
  - `tests/unit/main/windowsReleaseWorkflowTopology.test.ts`
- Confirmed sidecar payload entries are included in `windowsUploadFiles` output.

## Scope / risk

- Scoped to Windows release/build pipeline and supporting docs/tests.
- No runtime feature logic changes.
- Linux/mac release behavior not intentionally changed.