### PR TITLE
chore: release v0.11.2

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,6 +43,12 @@ Priorities may shift based on user feedback, upstream Gemini changes, and platfo
 - **Release and test reliability improvements** — dedupe zoom integration coverage and increase Windows release/integration timeout limits to reduce flaky release gates. ([#203](https://github.com/bwendell/gemini-desktop/pull/203), [#205](https://github.com/bwendell/gemini-desktop/pull/205))
 - **Documentation and developer workflow updates** — refresh architecture references and setup guidance for cleaner contributor onboarding and handoff context. ([#206](https://github.com/bwendell/gemini-desktop/pull/206), [#201](https://github.com/bwendell/gemini-desktop/pull/201), [#199](https://github.com/bwendell/gemini-desktop/pull/199), [#197](https://github.com/bwendell/gemini-desktop/pull/197), [#194](https://github.com/bwendell/gemini-desktop/pull/194))
 
+### v0.11.2 — Windows Installer Reliability
+
+- **Unified Windows installer release validation** — automate the unified Windows installer path with hosted smoke and upgrade coverage for x64 and ARM64, plus baseline-installer resolution for safer release verification. ([#227](https://github.com/bwendell/gemini-desktop/pull/227))
+- **Windows installer packaging fix** — include NSIS sidecar payloads in the release contract and harden local `dist:win` packaging so Windows installs ship complete payloads. Contributor credit: [@kevinofsydney](https://github.com/kevinofsydney). ([#275](https://github.com/bwendell/gemini-desktop/pull/275), [#274](https://github.com/bwendell/gemini-desktop/issues/274))
+- **Maintenance updates** — roll forward dependency and workflow updates merged after `v0.11.1` to keep the desktop, release, and CI toolchain current. ([#250](https://github.com/bwendell/gemini-desktop/pull/250), [#258](https://github.com/bwendell/gemini-desktop/pull/258), [#261](https://github.com/bwendell/gemini-desktop/pull/261), [#270](https://github.com/bwendell/gemini-desktop/pull/270), [#271](https://github.com/bwendell/gemini-desktop/pull/271), [#273](https://github.com/bwendell/gemini-desktop/pull/273), [#276](https://github.com/bwendell/gemini-desktop/pull/276))
+
 ## Near-Term Focus
 
 - Continue strengthening release quality and upgrade reliability across platforms.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gemini-desktop",
-    "version": "0.11.1",
+    "version": "0.11.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gemini-desktop",
-            "version": "0.11.1",
+            "version": "0.11.2",
             "dependencies": {
                 "dbus-next": "^0.10.2",
                 "electron-log": "^5.4.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A desktop wrapper for Google Gemini with enhanced features",
     "author": "Ben Wendell <github@benwendell.com>",
     "private": true,
-    "version": "0.11.1",
+    "version": "0.11.2",
     "type": "module",
     "main": "dist-electron/main/main.cjs",
     "keywords": [


### PR DESCRIPTION
## Release v0.11.2

This PR prepares the `v0.11.2` release by bumping version metadata and finalizing roadmap notes for all merged PRs since `v0.11.1`.

### Key Changes
- Bump app version from `0.11.1` to `0.11.2` in `package.json` and `package-lock.json`.
- Expand the roadmap `v0.11.2` section in `docs/ROADMAP.md` to summarize shipped work merged since `v0.11.1`.
- Include the unified Windows installer release-validation work from [#227](https://github.com/bwendell/gemini-desktop/pull/227), covering hosted smoke and upgrade validation for x64 and ARM64.
- Include the Windows installer packaging fix from [#275](https://github.com/bwendell/gemini-desktop/pull/275) for [#274](https://github.com/bwendell/gemini-desktop/issues/274), with contributor credit to [@kevinofsydney](https://github.com/kevinofsydney) for shipping the NSIS sidecar packaging fix and `dist:win` hardening.
- Roll forward maintenance updates merged after `v0.11.1`, including [#250](https://github.com/bwendell/gemini-desktop/pull/250), [#258](https://github.com/bwendell/gemini-desktop/pull/258), [#261](https://github.com/bwendell/gemini-desktop/pull/261), [#270](https://github.com/bwendell/gemini-desktop/pull/270), [#271](https://github.com/bwendell/gemini-desktop/pull/271), [#273](https://github.com/bwendell/gemini-desktop/pull/273), and [#276](https://github.com/bwendell/gemini-desktop/pull/276).

### Verification
- `npm run lint`
- `npm run test` (55 files passed, 647 tests passed, 4 skipped)
- `npm run build`