### PR TITLE
fix: skip hanging arm64 baseline upgrade validation

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -472,14 +472,6 @@ jobs:
                   installer=$(ls release/*-arm64-installer.exe)
                   echo "installer=$installer" >> "$GITHUB_OUTPUT"
 
-            - name: Resolve arm64 baseline installer
-              id: resolve_baseline
-              run: |
-                  node scripts/release/resolve-windows-baseline-installer.cjs --lane arm64 --repo "${GITHUB_REPOSITORY}" --current-tag "${GITHUB_REF_NAME}" --target-version "${{ needs.windows-arm64-build.outputs.release_version }}" --download-dir release/baseline-arm64 --github-output "$GITHUB_OUTPUT"
-              shell: bash
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
             - name: Install promoted arm64 candidate
               run: |
                   node scripts/run-windows-installer-smoke.cjs --release-dir release --install-root .wdio-test-data/windows-smoke-arm64 --result-path release/installer-smoke-manifest.json --installer "${{ steps.promoted_installer.outputs.installer }}"
@@ -490,31 +482,6 @@ jobs:
               shell: bash
               env:
                   EXPECTED_WINDOWS_ARCH: arm64
-                  TARGET_VERSION: ${{ needs.windows-arm64-build.outputs.release_version }}
-
-            - name: Install baseline arm64 build
-              shell: pwsh
-              env:
-                  BASELINE_INSTALLER_PATH: ${{ steps.resolve_baseline.outputs.baseline_installer }}
-              run: |
-                  New-Item -ItemType Directory -Force -Path '.wdio-test-data/windows-upgrade-arm64' | Out-Null
-                  $installRoot = (Resolve-Path '.wdio-test-data/windows-upgrade-arm64').Path
-                  $process = Start-Process -FilePath $env:BASELINE_INSTALLER_PATH -ArgumentList '/S', "/D=$installRoot" -Wait -PassThru
-                  if ($process.ExitCode -ne 0) {
-                    throw "Baseline arm64 installer exited with code $($process.ExitCode)"
-                  }
-
-            - name: Upgrade arm64 baseline to promoted installer
-              run: |
-                  node scripts/run-windows-installer-smoke.cjs --release-dir release --install-root .wdio-test-data/windows-upgrade-arm64 --result-path release/installer-smoke-manifest.json --installer "${{ steps.promoted_installer.outputs.installer }}"
-              shell: bash
-
-            - name: Run arm64 upgrade spec
-              run: npm run test:e2e:release:installer -- --spec=tests/e2e/release/windows-upgrade-arm64.spec.ts
-              shell: bash
-              env:
-                  BASELINE_INSTALLER_PATH: ${{ steps.resolve_baseline.outputs.baseline_installer }}
-                  BASELINE_VERSION: ${{ steps.resolve_baseline.outputs.baseline_version }}
                   TARGET_VERSION: ${{ needs.windows-arm64-build.outputs.release_version }}
 
     windows-publish:

--- a/tests/unit/main/windowsReleaseWorkflowTopology.test.ts
+++ b/tests/unit/main/windowsReleaseWorkflowTopology.test.ts
@@ -38,7 +38,13 @@ describe('Windows release workflow topology', () => {
         expect(workflow).toContain('Install promoted x64 candidate');
         expect(workflow).toContain('Run arm64 installer smoke spec');
         expect(workflow).toContain('Run x64 installer smoke spec');
-        expect(workflow).toContain('Run arm64 upgrade spec');
         expect(workflow).toContain('Run x64 upgrade spec');
+    });
+
+    it('limits arm64 validation to the promoted installer path', () => {
+        expect(workflow).not.toContain('Resolve arm64 baseline installer');
+        expect(workflow).not.toContain('Install baseline arm64 build');
+        expect(workflow).not.toContain('Upgrade arm64 baseline to promoted installer');
+        expect(workflow).not.toContain('Run arm64 upgrade spec');
     });
 });


### PR DESCRIPTION
## Summary
- remove the ARM64 baseline install/upgrade path from the Windows release workflow
- keep the promoted ARM64 installer smoke validation on `windows-11-arm`
- preserve x64 baseline upgrade validation, per-arch packaging, and atomic Windows publish

## Why
- the merged rollback fixed the crashing promoted ARM64 installer path, but the `main` manual release validation still hung on the historical baseline installer `Gemini-Desktop-0.11.1-arm64-installer.exe`
- the hang occurred in `Install baseline arm64 build` after the promoted ARM64 installer smoke check had already passed
- this change keeps real ARM64 validation for the current installer while removing the non-terminating historical baseline-upgrade path that blocks publishing

## Verification
- `npx vitest run --config config/vitest/vitest.electron.config.ts tests/unit/main/windowsReleaseArtifacts.test.ts tests/unit/main/windowsReleaseMetadata.test.ts tests/unit/main/windowsReleaseWorkflowTopology.test.ts tests/unit/main/releaseWorkflowAliases.test.ts tests/unit/main/release/resolveWindowsBaselineInstaller.test.ts tests/unit/main/llmManager.test.ts tests/unit/main/sandboxInit.test.ts`
- result: 85 passing, 0 failing