### PR TITLE
fix(release): remove unsupported macOS ZIP artifact

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -61,7 +61,7 @@ jobs:
             - name: Generate Checksums
               run: |
                   cd release
-                  shasum -a 256 *.dmg *.zip > checksums-macos-x64.txt
+                  shasum -a 256 *.dmg > checksums-macos-x64.txt
 
             - name: Prepare macOS update metadata (x64)
               run: |
@@ -80,8 +80,6 @@ jobs:
                   fail_on_unmatched_files: true
                   files: |
                       release/*.dmg
-                      release/*.zip
-                      release/*.zip.blockmap
                       release/checksums-macos-x64.txt
                       release/latest-mac-x64.yml
               env:
@@ -137,7 +135,7 @@ jobs:
             - name: Generate Checksums
               run: |
                   cd release
-                  shasum -a 256 *.dmg *.zip > checksums-macos-arm64.txt
+                  shasum -a 256 *.dmg > checksums-macos-arm64.txt
 
             - name: Prepare macOS update metadata (arm64)
               run: |
@@ -156,8 +154,6 @@ jobs:
                   fail_on_unmatched_files: true
                   files: |
                       release/*.dmg
-                      release/*.zip
-                      release/*.zip.blockmap
                       release/checksums-macos-arm64.txt
                       release/latest-mac-arm64.yml
               env:

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -102,7 +102,7 @@ module.exports = {
         artifactName: 'Gemini-Desktop-${version}-${arch}-installer.${ext}',
     },
     mac: {
-        target: ['dmg', 'zip'],
+        target: ['dmg'],
         icon: 'build/icon.png',
         identity: null,
         artifactName: 'Gemini-Desktop-${version}-${arch}.${ext}',

--- a/tests/unit/main/releaseWorkflowAliases.test.ts
+++ b/tests/unit/main/releaseWorkflowAliases.test.ts
@@ -1,11 +1,27 @@
 import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const workflowPath = path.resolve(__dirname, '../../..', '.github/workflows/_release.yml');
 const workflow = fs.readFileSync(workflowPath, 'utf8');
+const require = createRequire(import.meta.url);
+const builderConfigPath = path.resolve(__dirname, '../../..', 'config/electron-builder.config.cjs');
+
+type TargetConfig = string | { target: string };
+type ElectronBuilderConfig = {
+    mac?: {
+        target?: TargetConfig[];
+    };
+};
+
+const builderConfig = require(builderConfigPath) as ElectronBuilderConfig;
+
+function getTargetNames(targets: TargetConfig[] | undefined): string[] {
+    return targets?.map((target) => (typeof target === 'string' ? target : target.target)) ?? [];
+}
 
 describe('release workflow Windows metadata aliases', () => {
     it('prepares aliases inline for per-architecture release jobs', () => {
@@ -24,5 +40,20 @@ describe('release workflow Windows metadata aliases', () => {
         expect(workflow).toContain('release/checksums-windows.txt');
         expect(workflow).toContain('release/checksums-windows-arm64.txt');
         expect(workflow).not.toContain('release/*.msi');
+    });
+});
+
+describe('electron-builder macOS release artifacts', () => {
+    it('does not build unsupported macOS ZIP artifacts', () => {
+        const macTargetNames = getTargetNames(builderConfig.mac?.target);
+
+        expect(macTargetNames).toContain('dmg');
+        expect(macTargetNames).not.toContain('zip');
+    });
+
+    it('does not publish unsupported macOS ZIP artifact globs', () => {
+        expect(workflow).not.toContain('*.dmg *.zip');
+        expect(workflow).not.toContain('release/*.zip');
+        expect(workflow).not.toContain('release/*.zip.blockmap');
     });
 });


### PR DESCRIPTION
## Summary
- remove the macOS ZIP target so releases only build DMG artifacts for macOS
- remove macOS ZIP checksum and upload globs from the release workflow
- add release contract coverage so macOS ZIP artifacts are not reintroduced

## Verification
- npm run test:electron -- tests/unit/main/releaseWorkflowAliases.test.ts
- npx eslint config/electron-builder.config.cjs tests/unit/main/releaseWorkflowAliases.test.ts
- npx prettier --check .github/workflows/_release.yml config/electron-builder.config.cjs tests/unit/main/releaseWorkflowAliases.test.ts