### PR TITLE
fix(linux): disable sandbox-incompatible native modules to stop startup crash (#119)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -21,6 +21,7 @@ import * as path from 'path';
 import { setupHeaderStripping, setupWebviewSecurity, setupMediaPermissions } from './utils/security';
 import { getDistHtmlPath } from './utils/paths';
 import { getPlatformAdapter } from './platform/platformAdapterFactory';
+import { detectWaylandSession } from './utils/waylandDetector';
 
 import { createLogger } from './utils/logger';
 
@@ -409,6 +410,16 @@ if (!gotTheLock) {
 
             // Inject NotificationManager into IpcManager for response notification IPC handlers
             appContext.ipcManager.setNotificationManager(notificationManager);
+
+            // One-time, per-version notice on Linux: global hotkeys (Wayland) and
+            // text prediction are disabled because their native modules are
+            // incompatible with Electron's V8 memory cage (issue #119).
+            if (process.platform === 'linux') {
+                notificationManager.maybeShowLinuxFeatureNotice({
+                    isWayland: detectWaylandSession(),
+                    appVersion: app.getVersion(),
+                });
+            }
         }
 
         // Create system tray icon (may fail on headless Linux environments)

--- a/src/main/managers/ipc/TextPredictionIpcHandler.ts
+++ b/src/main/managers/ipc/TextPredictionIpcHandler.ts
@@ -17,7 +17,7 @@
  * @module ipc/TextPredictionIpcHandler
  */
 
-import { app, ipcMain, BrowserWindow } from 'electron';
+import { ipcMain, BrowserWindow } from 'electron';
 import { BaseIpcHandler } from './BaseIpcHandler';
 import { IPC_CHANNELS } from '../../utils/constants';
 import type { TextPredictionSettings } from '../../../shared/types';
@@ -180,17 +180,10 @@ export class TextPredictionIpcHandler extends BaseIpcHandler {
             this.deps.store.set('textPredictionEnabled', enabled);
             this.logger.log(`Text prediction enabled set to: ${enabled}`);
 
-            // If enabling and LlmManager exists, trigger model download/load if needed
+            // If enabling and LlmManager exists, trigger model download/load if needed.
+            // Availability (including the Linux V8-memory-cage incompatibility, issue #119)
+            // is determined by llmManager.ensureNativeAvailable()/isNativeAvailable().
             if (enabled && this.deps.llmManager) {
-                if (process.platform === 'linux') {
-                    const jsFlags = app.commandLine.getSwitchValue('js-flags') ?? '';
-                    const v8SandboxDisabled = jsFlags.includes('--no-v8-sandbox');
-                    if (!v8SandboxDisabled) {
-                        this.logger.log('Linux: V8 sandbox still active, restart required for text prediction');
-                        this._broadcastStatusChange();
-                        return;
-                    }
-                }
                 const skipNativeOperations = process.env.CI === 'true' || process.argv.includes('--integration-test');
 
                 if (skipNativeOperations) {
@@ -365,25 +358,6 @@ export class TextPredictionIpcHandler extends BaseIpcHandler {
         const nativeAvailable = this.deps.llmNativeAvailable ?? this.deps.llmManager?.isNativeAvailable() ?? false;
         const modelStatus = this.deps.llmManager?.getStatus();
         const storedStatus = this.deps.store.get('textPredictionModelStatus') as ModelStatus | undefined;
-        let requiresRestart = false;
-
-        if (enabled && process.platform === 'linux') {
-            const jsFlags = app.commandLine.getSwitchValue('js-flags') ?? '';
-            requiresRestart = !jsFlags.includes('--no-v8-sandbox');
-        }
-
-        if (requiresRestart) {
-            return {
-                enabled,
-                gpuEnabled: this.deps.store.get('textPredictionGpuEnabled') ?? false,
-                status: 'requires-restart',
-                requiresRestart: true,
-                restartReason:
-                    'Text prediction on Linux requires disabling the V8 memory sandbox. ' +
-                    'This is a security feature that conflicts with the local AI engine. ' +
-                    'The app needs to restart to apply this change.',
-            };
-        }
 
         const status = nativeAvailable ? (modelStatus ?? storedStatus ?? 'not-downloaded') : 'error';
         const errorMessage =

--- a/src/main/managers/llmManager.ts
+++ b/src/main/managers/llmManager.ts
@@ -142,13 +142,48 @@ export default class LlmManager {
         logger.log('LlmManager created');
     }
 
+    /**
+     * Message reported when text prediction is requested on a platform where it
+     * cannot run. node-llama-cpp allocates ArrayBuffer backing stores OUTSIDE
+     * Electron's V8 memory cage, which FATAL-aborts the process on Linux. There
+     * is no runtime switch to disable the cage, so the feature is turned off on
+     * Linux until the engine can be run out of the cage.
+     *
+     * @see https://github.com/bwendell/gemini-desktop/issues/119
+     */
+    static readonly UNSUPPORTED_PLATFORM_MESSAGE =
+        'Text prediction is not supported on Linux in this build. The local AI engine (node-llama-cpp) ' +
+        "is incompatible with the app's V8 memory cage, which would crash the app at startup.";
+
     private isTextPredictionTestMode(): boolean {
         return process.argv.includes('--test-text-prediction');
+    }
+
+    /**
+     * Whether the local text-prediction engine can run on the current platform.
+     *
+     * Disabled on Linux because node-llama-cpp is incompatible with Electron's
+     * V8 memory cage (issue #119). Windows and macOS are unaffected.
+     */
+    isSupportedOnPlatform(): boolean {
+        return process.platform !== 'linux';
     }
 
     ensureNativeAvailable(context: string): boolean {
         if (this.nativeAvailable !== null) {
             return this.nativeAvailable;
+        }
+
+        // Gate on platform BEFORE the test/CI bypasses so native availability
+        // accurately reflects that the feature is unavailable on Linux.
+        if (!this.isSupportedOnPlatform()) {
+            this.nativeAvailable = false;
+            this.nativeProbeError = LlmManager.UNSUPPORTED_PLATFORM_MESSAGE;
+            logger.warn('Text prediction is not supported on this platform', {
+                context,
+                platform: process.platform,
+            });
+            return false;
         }
 
         if (process.env.NODE_ENV === 'test') {
@@ -498,21 +533,23 @@ export default class LlmManager {
             });
         } catch (error) {
             const message = error instanceof Error ? error.message : 'Failed to load model';
-            const isV8SandboxError =
+            const isV8CageError =
                 typeof message === 'string' &&
                 (message.includes('v8_ArrayBuffer_NewBackingStore') ||
                     message.includes('V8 Sandbox') ||
                     message.includes('sandbox address space'));
 
-            if (isV8SandboxError) {
-                const v8Message =
-                    'V8 sandbox conflict detected while loading the local AI engine. ' +
-                    'On Linux, enabling text prediction requires disabling the V8 memory sandbox and restarting the app.';
+            if (isV8CageError) {
+                // The native engine allocated an ArrayBuffer outside Electron's
+                // V8 memory cage — the issue #119 crash class. There is no
+                // runtime flag that fixes this, so report it as unsupported
+                // rather than suggesting an (impossible) restart-with-flag.
+                const cageMessage = LlmManager.UNSUPPORTED_PLATFORM_MESSAGE;
                 this.nativeAvailable = false;
-                this.nativeProbeError = v8Message;
-                this.setStatus('error', v8Message);
-                logger.error('Failed to load model due to V8 sandbox conflict', { error });
-                throw new Error(v8Message);
+                this.nativeProbeError = cageMessage;
+                this.setStatus('error', cageMessage);
+                logger.error('Failed to load model: native engine incompatible with the V8 memory cage', { error });
+                throw new Error(cageMessage);
             }
 
             logger.error('Failed to load model', { error });

--- a/src/main/managers/notificationManager.ts
+++ b/src/main/managers/notificationManager.ts
@@ -22,6 +22,12 @@ const logger = createLogger('[NotificationManager]');
  */
 export interface NotificationSettings extends Record<string, unknown> {
     responseNotificationsEnabled: boolean;
+    /**
+     * App version for which the one-time "some Linux features are unavailable"
+     * notice (issue #119) was last shown. Used to show the notice at most once
+     * per app version.
+     */
+    linuxFeatureNoticeShownForVersion?: string;
 }
 
 /**
@@ -273,6 +279,105 @@ export default class NotificationManager {
             logger.log('Notification shown');
         } catch (error) {
             logger.error('Failed to show notification:', error);
+        }
+    }
+
+    /**
+     * Show a generic informational OS notification.
+     *
+     * Unlike {@link showNotification}, this is not tied to the response-complete
+     * flow or the `responseNotificationsEnabled` preference — it is for one-off
+     * informational messages (e.g. the Linux feature notice). All failures are
+     * contained so a notification problem never crashes the app.
+     *
+     * @param title - Notification title
+     * @param body - Notification body text
+     */
+    showInfoNotification(title: string, body: string): void {
+        if (!Notification.isSupported()) {
+            const hint = this.platformAdapter.getNotificationSupportHint();
+            if (hint) {
+                logger.warn(hint);
+            } else {
+                logger.log('Notifications not supported on this platform');
+            }
+            return;
+        }
+
+        let iconPath: string | undefined = getNotificationIconPath();
+        if (iconPath && !fs.existsSync(iconPath)) {
+            logger.warn(`Notification icon not found at path: ${iconPath} - notification will show without icon`);
+            iconPath = undefined;
+        }
+
+        let notification: Notification;
+        try {
+            notification = new Notification({
+                title,
+                body,
+                silent: true,
+                icon: iconPath,
+            });
+        } catch (error) {
+            logger.error('Failed to create info notification:', error);
+            return;
+        }
+
+        notification.on('click', () => {
+            this.focusMainWindow();
+        });
+
+        this.activeNotifications.add(notification);
+        notification.on('close', () => {
+            this.activeNotifications.delete(notification);
+        });
+
+        try {
+            notification.show();
+            logger.log('Info notification shown', { title });
+        } catch (error) {
+            logger.error('Failed to show info notification:', error);
+        }
+    }
+
+    /**
+     * Show the one-time "some Linux features are unavailable" notice (issue #119),
+     * at most once per app version.
+     *
+     * Global hotkeys (Wayland) and text prediction are disabled on Linux because
+     * they depend on native modules incompatible with Electron's V8 memory cage.
+     * This surfaces that to the user instead of letting them hit a startup crash.
+     *
+     * @param params.isWayland - Whether the current session is Wayland (affects copy)
+     * @param params.appVersion - Current app version, used for the once-per-version guard
+     */
+    maybeShowLinuxFeatureNotice(params: { isWayland: boolean; appVersion: string }): void {
+        const { isWayland, appVersion } = params;
+        try {
+            const shownForVersion = this.store.get('linuxFeatureNoticeShownForVersion');
+            if (shownForVersion === appVersion) {
+                logger.log('Linux feature notice already shown for this version, skipping', { appVersion });
+                return;
+            }
+
+            const title = isWayland ? 'Some Linux features are unavailable' : 'Text prediction is unavailable on Linux';
+            const body = isWayland
+                ? 'Global hotkeys and text prediction are turned off on Linux in this version because they rely ' +
+                  "on native modules that are incompatible with the app's security sandbox (Electron's V8 memory " +
+                  'cage). Keeping them off prevents a startup crash. A fix is being worked on — see issue #119.'
+                : 'Text prediction is turned off on Linux in this version because it relies on a native module ' +
+                  "that is incompatible with the app's security sandbox (Electron's V8 memory cage). Keeping it " +
+                  'off prevents a startup crash. A fix is being worked on — see issue #119.';
+
+            this.showInfoNotification(title, body);
+
+            try {
+                this.store.set('linuxFeatureNoticeShownForVersion', appVersion);
+            } catch (error) {
+                logger.error('Failed to persist linux feature notice flag:', error);
+            }
+        } catch (error) {
+            logger.error('Failed to evaluate linux feature notice:', error);
         }
     }
 

--- a/src/main/platform/adapters/LinuxWaylandAdapter.ts
+++ b/src/main/platform/adapters/LinuxWaylandAdapter.ts
@@ -84,13 +84,25 @@ export class LinuxWaylandAdapter implements PlatformAdapter {
     /**
      * Determine hotkey registration strategy for Wayland.
      *
-     * Returns `wayland-dbus` when the XDG Desktop Portal GlobalShortcuts
-     * interface is available, `disabled` otherwise.
+     * Global shortcuts on Wayland are registered through the XDG Desktop Portal
+     * via the `dbus-next` library, whose native `usocket` transport allocates
+     * ArrayBuffer backing stores OUTSIDE Electron's V8 memory cage. With the
+     * cage enabled (the default since Electron 21) that triggers a fatal
+     * `v8_ArrayBuffer_NewBackingStore` abort / segfault at startup on Wayland
+     * (issue #119).
+     *
+     * Until the D-Bus path is reworked to use a Node `net`-based unix-socket
+     * transport (out of scope for this hotfix), the Wayland portal path is
+     * force-disabled so `dbus-next`/`usocket` is never imported. The real
+     * Wayland status is still returned for diagnostics and the user-facing
+     * "features unavailable" notice.
+     *
+     * @see https://github.com/bwendell/gemini-desktop/issues/119
      */
     getHotkeyRegistrationPlan(): HotkeyRegistrationPlan {
         const waylandStatus = getWaylandPlatformStatus();
         return {
-            mode: waylandStatus.portalAvailable ? 'wayland-dbus' : 'disabled',
+            mode: 'disabled',
             waylandStatus,
         };
     }

--- a/src/main/utils/dbusFallback.ts
+++ b/src/main/utils/dbusFallback.ts
@@ -425,6 +425,22 @@ function parseShortcutSignalPayload(msg: DBusMessage): PortalShortcutSignalPaylo
 // ============================================================================
 
 /**
+ * Defense-in-depth guard for the `dbus-next` dynamic-import sites.
+ *
+ * `dbus-next` pulls in the native `usocket` addon, which allocates ArrayBuffer
+ * backing stores OUTSIDE Electron's V8 memory cage. Importing/using it while
+ * the cage is enabled FATAL-aborts the process at startup (issue #119). The
+ * hotkey planner already forces the Wayland path to `disabled` so this code is
+ * not reached on Linux, but we additionally refuse to import `dbus-next` here
+ * as a last line of defense.
+ *
+ * @see https://github.com/bwendell/gemini-desktop/issues/119
+ */
+function isDBusTransportDisabled(): boolean {
+    return process.platform === 'linux';
+}
+
+/**
  * Check whether the D-Bus GlobalShortcuts interface is available.
  *
  * This function dynamically imports `dbus-next` so the dependency is only
@@ -433,6 +449,10 @@ function parseShortcutSignalPayload(msg: DBusMessage): PortalShortcutSignalPaylo
  * @returns `true` if the portal interface is available
  */
 export async function isDBusFallbackAvailable(): Promise<boolean> {
+    if (isDBusTransportDisabled()) {
+        logger.warn('D-Bus fallback disabled on Linux (V8 memory cage / usocket incompatibility, issue #119)');
+        return false;
+    }
     try {
         const dbusNext = await import('dbus-next');
         const bus = dbusNext.sessionBus() as DBusConnection;
@@ -485,6 +505,18 @@ export async function registerViaDBus(
     // Early exit for empty array
     if (shortcuts.length === 0) {
         return [];
+    }
+
+    // Defense-in-depth: never import dbus-next/usocket while the V8 cage is on (issue #119)
+    if (isDBusTransportDisabled()) {
+        logger.warn(
+            'Skipping D-Bus shortcut registration on Linux (V8 memory cage / usocket incompatibility, issue #119)'
+        );
+        return shortcuts.map((s) => ({
+            hotkeyId: s.id,
+            success: false,
+            error: 'Global shortcuts via the D-Bus portal are disabled on Linux in this build (issue #119)',
+        }));
     }
 
     try {

--- a/src/main/utils/sandboxInit.ts
+++ b/src/main/utils/sandboxInit.ts
@@ -8,37 +8,20 @@
  * ES import statements are hoisted, so inline code in main.ts would run AFTER
  * all imports have been evaluated. By placing detection in a separate module
  * imported first, we guarantee it executes before constants.ts evaluates.
+ *
+ * NOTE: This module intentionally does NOT touch the V8 sandbox / V8 memory
+ * cage. That cage is a compile-time feature of Electron and cannot be turned
+ * off at runtime — passing a JS flag to disable it has no effect (V8 prints
+ * "unrecognized flag"). The startup crash on Linux (issue #119) is instead
+ * mitigated by never loading the native modules that allocate ArrayBuffers
+ * outside the cage (dbus-next/usocket and node-llama-cpp); see hotkeyManager,
+ * dbusFallback, and llmManager. The `no-sandbox` (Chromium) switch below is an
+ * unrelated, legitimate AppImage compatibility measure.
  */
 
 import { app } from 'electron';
-import * as fs from 'fs';
-import * as path from 'path';
 import { shouldDisableSandbox } from './sandboxDetector';
 
 if (shouldDisableSandbox()) {
     app.commandLine.appendSwitch('no-sandbox');
-}
-
-if (process.platform === 'linux') {
-    try {
-        const settingsPath = path.join(app.getPath('userData'), 'settings.json');
-        const raw = fs.readFileSync(settingsPath, 'utf-8');
-        const settings = JSON.parse(raw) as { textPredictionEnabled?: boolean };
-
-        if (settings?.textPredictionEnabled === true) {
-            app.commandLine.appendSwitch('js-flags', '--no-v8-sandbox');
-        }
-    } catch (error) {
-        const err = error as NodeJS.ErrnoException;
-        if (err?.code !== 'ENOENT' && process.env.NODE_ENV !== 'test') {
-            console.warn(
-                '[sandboxInit] Failed to read or parse settings.json; V8 sandbox may not be disabled as expected.',
-                err
-            );
-        }
-    }
-}
-
-if (process.platform === 'linux' && process.argv.includes('--test-text-prediction')) {
-    app.commandLine.appendSwitch('js-flags', '--no-v8-sandbox');
 }

--- a/src/renderer/components/options/TextPredictionSettings.css
+++ b/src/renderer/components/options/TextPredictionSettings.css
@@ -176,70 +176,40 @@
     outline-offset: 2px;
 }
 
-.text-prediction-restart {
+/* === Unavailable notice (e.g. Linux: text prediction disabled, issue #119) === */
+
+.text-prediction-unavailable {
     display: flex;
     gap: 12px;
     padding: 14px 16px;
     border-radius: 8px;
-    border: 1px solid rgba(255, 183, 77, 0.6);
-    background: rgba(255, 183, 77, 0.08);
+    border: 1px solid rgba(100, 181, 246, 0.6);
+    background: rgba(100, 181, 246, 0.08);
     color: var(--text-primary, #eaeaea);
 }
 
-.text-prediction-restart__icon {
+.text-prediction-unavailable__icon {
     font-size: 18px;
     line-height: 1;
 }
 
-.text-prediction-restart__content {
+.text-prediction-unavailable__content {
     display: flex;
     flex-direction: column;
     gap: 6px;
     flex: 1;
 }
 
-.text-prediction-restart__title {
+.text-prediction-unavailable__title {
     font-size: 14px;
     font-weight: 600;
-    color: var(--warning-color, #ffb74d);
+    color: var(--info-color, #64b5f6);
 }
 
-.text-prediction-restart__message {
+.text-prediction-unavailable__message {
     font-size: 12px;
     color: var(--text-secondary, #b0b0b0);
     line-height: 1.4;
-}
-
-.text-prediction-restart__button {
-    align-self: flex-start;
-    padding: 6px 14px;
-    font-size: 12px;
-    font-weight: 600;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    background-color: var(--warning-color, #ffb74d);
-    color: #1a1a1a;
-    transition:
-        opacity 0.2s ease,
-        transform 0.1s ease;
-}
-
-.text-prediction-restart__button:hover {
-    opacity: 0.9;
-}
-
-.text-prediction-restart__button:active {
-    transform: scale(0.98);
-}
-
-.text-prediction-restart__button:focus {
-    outline: none;
-}
-
-.text-prediction-restart__button:focus-visible {
-    outline: 2px solid var(--warning-color, #ffb74d);
-    outline-offset: 2px;
 }
 
 /* === Debug Mode === */

--- a/src/renderer/components/options/TextPredictionSettings.tsx
+++ b/src/renderer/components/options/TextPredictionSettings.tsx
@@ -9,7 +9,7 @@
 
 import { memo, useState, useEffect, useCallback, useRef } from 'react';
 import { CapsuleToggle } from '../common/CapsuleToggle';
-import { isDevMode } from '../../utils/platform';
+import { isDevMode, isLinux } from '../../utils/platform';
 import { createRendererLogger } from '../../utils';
 import type { TextPredictionSettings as TextPredictionSettingsType } from '../../../shared/types/text-prediction';
 import './TextPredictionSettings.css';
@@ -91,15 +91,11 @@ export const TextPredictionSettings = memo(function TextPredictionSettings() {
         }
     }, []);
 
-    const requiresRestart = settings.requiresRestart ?? settings.status === 'requires-restart';
-
-    const handleRestart = useCallback(async () => {
-        try {
-            await window.electronAPI?.restartApp();
-        } catch (error) {
-            logger.error('Failed to restart app:', error);
-        }
-    }, []);
+    // Text prediction relies on node-llama-cpp, a native module incompatible
+    // with Electron's V8 memory cage on Linux (issue #119). The feature is
+    // disabled there, so the toggle is shown as unavailable instead of letting
+    // a user enable it and crash the app.
+    const unavailableOnPlatform = isLinux();
 
     // Handle GPU toggle change
     const handleGpuChange = useCallback(async (newEnabled: boolean) => {
@@ -160,34 +156,32 @@ export const TextPredictionSettings = memo(function TextPredictionSettings() {
 
     return (
         <div className="text-prediction-settings" data-testid="text-prediction-settings">
-            {/* Enable toggle */}
+            {/* Enable toggle (disabled on Linux — feature unavailable, issue #119) */}
             <CapsuleToggle
-                checked={settings.enabled}
+                checked={unavailableOnPlatform ? false : settings.enabled}
                 onChange={handleEnableChange}
+                disabled={unavailableOnPlatform}
                 label="Enable Text Prediction (Experimental)"
                 description="Use local AI to suggest text completions in Quick Chat"
                 testId="text-prediction-enable-toggle"
             />
 
-            {requiresRestart ? (
-                <div className="text-prediction-restart" data-testid="text-prediction-restart-notice">
-                    <div className="text-prediction-restart__icon" aria-hidden="true">
-                        ⚠️
+            {unavailableOnPlatform ? (
+                <div
+                    className="text-prediction-unavailable"
+                    data-testid="text-prediction-linux-unavailable"
+                    role="note"
+                >
+                    <div className="text-prediction-unavailable__icon" aria-hidden="true">
+                        ⓘ
                     </div>
-                    <div className="text-prediction-restart__content">
-                        <div className="text-prediction-restart__title">Restart Required</div>
-                        <div className="text-prediction-restart__message">
-                            {settings.restartReason ??
-                                'Text prediction requires a restart to apply security-related changes.'}
+                    <div className="text-prediction-unavailable__content">
+                        <div className="text-prediction-unavailable__title">Unavailable on Linux</div>
+                        <div className="text-prediction-unavailable__message">
+                            Text prediction is turned off on Linux in this version because the local AI engine relies on
+                            a native module that is incompatible with the app&apos;s security sandbox (Electron&apos;s
+                            V8 memory cage). A fix is being worked on — see issue #119.
                         </div>
-                        <button
-                            className="text-prediction-restart__button"
-                            onClick={handleRestart}
-                            type="button"
-                            data-testid="text-prediction-restart-button"
-                        >
-                            Restart Now
-                        </button>
                     </div>
                 </div>
             ) : (

--- a/src/shared/types/text-prediction.ts
+++ b/src/shared/types/text-prediction.ts
@@ -7,7 +7,7 @@
 /**
  * Status of the local LLM model.
  */
-export type ModelStatus = 'not-downloaded' | 'downloading' | 'initializing' | 'ready' | 'error' | 'requires-restart';
+export type ModelStatus = 'not-downloaded' | 'downloading' | 'initializing' | 'ready' | 'error';
 
 /**
  * Text prediction settings and status information.
@@ -21,8 +21,6 @@ export interface TextPredictionSettings {
     status: ModelStatus;
     /** Download progress percentage (0-100), present during download */
     downloadProgress?: number;
-    requiresRestart?: boolean;
-    restartReason?: string;
     /** Error message if status is 'error' */
     errorMessage?: string;
 }

--- a/tests/coordinated/ipc/TextPredictionIpcHandler.coordinated.test.ts
+++ b/tests/coordinated/ipc/TextPredictionIpcHandler.coordinated.test.ts
@@ -4,7 +4,6 @@
  * Tests startup initialization flow (4.3.23) and full enable/disable cycle (4.3.24).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { App } from 'electron';
 import { ipcMain, BrowserWindow } from 'electron';
 import IpcManager from '../../../src/main/managers/ipcManager';
 import WindowManager from '../../../src/main/managers/windowManager';
@@ -27,14 +26,11 @@ vi.mock('electron-updater', () => ({
 describe('TextPredictionIpcHandler Coordinated Tests', () => {
     let mockStore: any;
     let mockLlmManager: any;
-    let app: App;
 
     beforeEach(async () => {
         vi.clearAllMocks();
         if ((ipcMain as any)._reset) (ipcMain as any)._reset();
         if ((BrowserWindow as any)._reset) (BrowserWindow as any)._reset();
-        const electron = await import('electron');
-        app = electron.app;
 
         const storeData: Record<string, any> = {
             textPredictionEnabled: false,
@@ -168,8 +164,6 @@ describe('TextPredictionIpcHandler Coordinated Tests', () => {
         });
 
         it('should coordinate full enable -> disable cycle', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            app.commandLine.getSwitchValue = vi.fn().mockReturnValue('--no-v8-sandbox');
             const windowManager = new WindowManager(false);
             const ipcManager = new IpcManager(
                 windowManager,
@@ -261,20 +255,15 @@ describe('TextPredictionIpcHandler Coordinated Tests', () => {
         });
     });
 
-    describe('Linux V8 Sandbox Restart Flow (Coordinated)', () => {
-        let originalPlatform: PropertyDescriptor | undefined;
+    describe('Native module unavailable (Linux, issue #119)', () => {
         let originalCI: string | undefined;
 
         beforeEach(() => {
-            originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
             originalCI = process.env.CI;
             delete process.env.CI;
         });
 
         afterEach(() => {
-            if (originalPlatform) {
-                Object.defineProperty(process, 'platform', originalPlatform);
-            }
             if (originalCI === undefined) {
                 delete process.env.CI;
             } else {
@@ -282,9 +271,14 @@ describe('TextPredictionIpcHandler Coordinated Tests', () => {
             }
         });
 
-        it('returns requires-restart status on Linux when V8 sandbox is active', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            app.commandLine.getSwitchValue = vi.fn().mockReturnValue('');
+        it('persists the preference but never loads the model when native module is unavailable', async () => {
+            // Simulates the real LlmManager reporting text prediction unsupported
+            // on Linux (isSupportedOnPlatform() === false → isNativeAvailable() === false).
+            mockLlmManager.isNativeAvailable = vi.fn().mockReturnValue(false);
+            mockLlmManager.ensureNativeAvailable = vi.fn().mockReturnValue(false);
+            mockLlmManager.getNativeProbeError = vi
+                .fn()
+                .mockReturnValue('Text prediction is not supported on Linux in this build.');
 
             const windowManager = new WindowManager(false);
             const ipcManager = new IpcManager(
@@ -304,59 +298,14 @@ describe('TextPredictionIpcHandler Coordinated Tests', () => {
 
             await setEnabledHandler({}, true);
 
+            // Preference is still recorded, but no native work happens (no crash).
             expect(mockStore.set).toHaveBeenCalledWith('textPredictionEnabled', true);
             expect(mockLlmManager.loadModel).not.toHaveBeenCalled();
+            expect(mockLlmManager.downloadModel).not.toHaveBeenCalled();
 
             const statusHandler = (ipcMain as any)._handlers.get('text-prediction:get-status');
             const status = await statusHandler({});
-            expect(status.status).toBe('requires-restart');
-            expect(status.requiresRestart).toBe(true);
-        });
-
-        it('proceeds with normal flow on Linux after V8 sandbox disabled', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            app.commandLine.getSwitchValue = vi.fn().mockReturnValue('--no-v8-sandbox');
-
-            const windowManager = new WindowManager(false);
-            const ipcManager = new IpcManager(
-                windowManager,
-                null,
-                null,
-                null,
-                mockLlmManager,
-                null,
-                mockStore,
-                mockLogger
-            );
-            ipcManager.setupIpcHandlers();
-
-            const setEnabledHandler = (ipcMain as any)._handlers.get('text-prediction:set-enabled');
-            await setEnabledHandler({}, true);
-
-            expect(mockLlmManager.loadModel).toHaveBeenCalled();
-        });
-
-        it('does not gate enable flow on non-Linux platforms', async () => {
-            Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
-            app.commandLine.getSwitchValue = vi.fn().mockReturnValue('');
-
-            const windowManager = new WindowManager(false);
-            const ipcManager = new IpcManager(
-                windowManager,
-                null,
-                null,
-                null,
-                mockLlmManager,
-                null,
-                mockStore,
-                mockLogger
-            );
-            ipcManager.setupIpcHandlers();
-
-            const setEnabledHandler = (ipcMain as any)._handlers.get('text-prediction:set-enabled');
-            await setEnabledHandler({}, true);
-
-            expect(mockLlmManager.loadModel).toHaveBeenCalled();
+            expect(status.status).toBe('error');
         });
     });
 });

--- a/tests/coordinated/sandbox-detection.coordinated.test.ts
+++ b/tests/coordinated/sandbox-detection.coordinated.test.ts
@@ -138,36 +138,4 @@ describe('Sandbox Detection Coordination', () => {
             process.argv = originalArgv;
         });
     });
-
-    describe('V8 sandbox flag independence from Chromium sandbox', () => {
-        it('V8 sandbox flag does not affect sandbox preference value', async () => {
-            app.commandLine.hasSwitch = vi.fn().mockReturnValue(false);
-            app.commandLine.getSwitchValue = vi.fn().mockReturnValue('--no-v8-sandbox');
-            const originalArgv = process.argv;
-            process.argv = ['node', 'main.js'];
-
-            const { getBaseWebPreferences } = await import('../../src/main/utils/constants');
-            const prefs = getBaseWebPreferences();
-
-            expect(prefs!.sandbox).toBe(true);
-
-            process.argv = originalArgv;
-        });
-
-        it('both sandbox flags can coexist without weakening other security defaults', async () => {
-            app.commandLine.hasSwitch = vi.fn().mockReturnValue(true);
-            app.commandLine.getSwitchValue = vi.fn().mockReturnValue('--no-v8-sandbox');
-            const originalArgv = process.argv;
-            process.argv = ['node', 'main.js', '--no-sandbox'];
-
-            const { getBaseWebPreferences } = await import('../../src/main/utils/constants');
-            const prefs = getBaseWebPreferences();
-
-            expect(prefs!.sandbox).toBe(false);
-            expect(prefs!.contextIsolation).toBe(true);
-            expect(prefs!.nodeIntegration).toBe(false);
-
-            process.argv = originalArgv;
-        });
-    });
 });

--- a/tests/coordinated/text-prediction-settings.coordinated.test.tsx
+++ b/tests/coordinated/text-prediction-settings.coordinated.test.tsx
@@ -14,10 +14,13 @@ import { TextPredictionSettings } from '../../src/renderer/components/options/Te
 import type { TextPredictionSettings as TextPredictionSettingsType } from '../../src/shared/types/text-prediction';
 import { setupMockElectronAPI } from '../helpers/mocks';
 
-// Mock platform utils
+// Mock platform utils. These coordination tests exercise the standard
+// (non-Linux) download/status UI, so isLinux() is forced false; the Linux
+// "unavailable" UI is covered by the TextPredictionSettings unit test.
 vi.mock('../../src/renderer/utils/platform', () => ({
     isDevMode: vi.fn().mockReturnValue(false),
     getIsDev: vi.fn().mockReturnValue(false),
+    isLinux: vi.fn().mockReturnValue(false),
 }));
 
 // Mock the renderer logger to avoid console noise

--- a/tests/e2e/release/native-module-health.spec.ts
+++ b/tests/e2e/release/native-module-health.spec.ts
@@ -15,14 +15,16 @@ describe('Release Build: Native Module Health', () => {
         expect(isPackaged).toBe(true);
     });
 
-    it('should have --js-flags command line switch set on Linux', async () => {
+    it('should NOT set the --js-flags switch on Linux (V8 cage left enabled, issue #119)', async () => {
         const platform = await browser.electron.execute(() => process.platform);
         if (platform !== 'linux') return;
 
+        // The startup crash is mitigated by not loading the offending native
+        // modules, NOT by a launch flag. The V8 memory cage stays enabled.
         const hasJsFlags = await browser.electron.execute((electron) => {
             return electron.app.commandLine.hasSwitch('js-flags');
         });
-        expect(hasJsFlags).toBe(true);
+        expect(hasJsFlags).toBe(false);
     });
 
     it('should NOT have --js-flags set on non-Linux platforms', async () => {

--- a/tests/e2e/release/text-prediction-packaged.spec.ts
+++ b/tests/e2e/release/text-prediction-packaged.spec.ts
@@ -14,6 +14,7 @@ describe('Release Build: Text Prediction', () => {
     });
 
     it('should return a prediction result without throwing', async () => {
+        const platform = await browser.electron.execute(() => process.platform);
         const result = await browser.execute(async () => {
             try {
                 return await (window as any).electronAPI.predictText('Hello from release');
@@ -21,6 +22,13 @@ describe('Release Build: Text Prediction', () => {
                 return { error: error?.message ?? String(error) };
             }
         });
+
+        // Text prediction is disabled on Linux (issue #119); the IPC call must
+        // still resolve cleanly (no crash) and return null rather than text.
+        if (platform === 'linux') {
+            expect(result).toBeNull();
+            return;
+        }
 
         if (typeof result === 'string') {
             expect(result.length).toBeGreaterThan(0);
@@ -30,14 +38,26 @@ describe('Release Build: Text Prediction', () => {
         throw new Error(`Prediction failed: ${result?.error ?? 'unknown error'}`);
     });
 
-    it('should have V8 sandbox disabled on Linux when text prediction is configured', async () => {
+    it('should leave the V8 cage enabled on Linux (no js-flags) and report cleanly', async () => {
         const platform = await browser.electron.execute(() => process.platform);
         if (platform !== 'linux') return;
 
+        // The V8 memory cage is intentionally left enabled (issue #119) — no
+        // js-flags launch switch is set.
         const hasJsFlags = await browser.electron.execute((electron) => {
             return electron.app.commandLine.hasSwitch('js-flags');
         });
-        expect(hasJsFlags).toBe(true);
+        expect(hasJsFlags).toBe(false);
+
+        // Querying text prediction status must not crash.
+        const status = await browser.execute(async () => {
+            try {
+                return await (window as any).electronAPI.getTextPredictionStatus();
+            } catch (error: any) {
+                return { error: error?.message ?? String(error) };
+            }
+        });
+        expect(status).toBeDefined();
     });
 
     it('should not have V8 sandbox crash errors in LlmManager', async () => {

--- a/tests/unit/main/ipc/TextPredictionIpcHandler.test.ts
+++ b/tests/unit/main/ipc/TextPredictionIpcHandler.test.ts
@@ -210,8 +210,6 @@ describe('TextPredictionIpcHandler', () => {
             delete process.env.CI;
             originalNodeEnv = process.env.NODE_ENV;
             process.env.NODE_ENV = 'production';
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            mockApp.commandLine.getSwitchValue.mockReturnValue('--no-v8-sandbox');
             mockLlmManager.isModelDownloaded.mockReturnValue(true);
             handler.register();
         });
@@ -439,8 +437,6 @@ describe('TextPredictionIpcHandler', () => {
             // Save and clear CI env to ensure download code path is exercised
             originalCI = process.env.CI;
             delete process.env.CI;
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            mockApp.commandLine.getSwitchValue.mockReturnValue('--no-v8-sandbox');
         });
 
         afterEach(() => {
@@ -554,8 +550,6 @@ describe('TextPredictionIpcHandler', () => {
 
     describe('text-prediction:get-status handler', () => {
         beforeEach(() => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            mockApp.commandLine.getSwitchValue.mockReturnValue('--no-v8-sandbox');
             handler.register();
         });
 
@@ -569,11 +563,7 @@ describe('TextPredictionIpcHandler', () => {
             mockLlmManager.getDownloadProgress.mockReturnValue(100);
 
             const handlerFn = mockIpcMain._handlers.get(IPC_CHANNELS.TEXT_PREDICTION_GET_STATUS);
-            const result = (await handlerFn!()) as {
-                status: string;
-                requiresRestart?: boolean;
-                restartReason?: string;
-            };
+            const result = (await handlerFn!()) as { status: string; downloadProgress?: number };
 
             expect(result).toEqual({
                 enabled: true,
@@ -582,180 +572,6 @@ describe('TextPredictionIpcHandler', () => {
                 downloadProgress: 100,
                 errorMessage: undefined,
             });
-        });
-    });
-
-    describe('Linux V8 sandbox restart flow', () => {
-        let originalPlatform: PropertyDescriptor | undefined;
-
-        beforeEach(() => {
-            originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
-            handler.register();
-        });
-
-        afterEach(() => {
-            if (originalPlatform) {
-                Object.defineProperty(process, 'platform', originalPlatform);
-            }
-        });
-
-        it('persists textPredictionEnabled = true on Linux with active V8 sandbox', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            mockApp.commandLine.getSwitchValue.mockReturnValue('');
-
-            const handlerFn = mockIpcMain._handlers.get(IPC_CHANNELS.TEXT_PREDICTION_SET_ENABLED);
-            await handlerFn!({}, true);
-
-            expect(mockStore.set).toHaveBeenCalledWith('textPredictionEnabled', true);
-        });
-
-        it('does not call loadModel when V8 sandbox is active', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            mockApp.commandLine.getSwitchValue.mockReturnValue('');
-
-            const handlerFn = mockIpcMain._handlers.get(IPC_CHANNELS.TEXT_PREDICTION_SET_ENABLED);
-            await handlerFn!({}, true);
-
-            expect(mockLlmManager.loadModel).not.toHaveBeenCalled();
-            expect(mockLlmManager.downloadModel).not.toHaveBeenCalled();
-        });
-
-        it('broadcasts requires-restart status when V8 sandbox is active', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            mockApp.commandLine.getSwitchValue.mockReturnValue('');
-
-            const handlerFn = mockIpcMain._handlers.get(IPC_CHANNELS.TEXT_PREDICTION_SET_ENABLED);
-            await handlerFn!({}, true);
-
-            expect(mockBrowserWindow._mockWebContents.send).toHaveBeenCalledWith(
-                IPC_CHANNELS.TEXT_PREDICTION_STATUS_CHANGED,
-                expect.objectContaining({
-                    status: 'requires-restart',
-                    requiresRestart: true,
-                })
-            );
-        });
-
-        it('proceeds with model loading when V8 sandbox is disabled', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            mockApp.commandLine.getSwitchValue.mockReturnValue('--no-v8-sandbox');
-            mockLlmManager.isModelDownloaded.mockReturnValue(true);
-            mockDeps.llmNativeAvailable = true;
-            process.env.NODE_ENV = 'production';
-            mockLlmManager.isModelLoaded.mockReturnValue(false);
-            delete process.env.CI;
-
-            const handlerFn = mockIpcMain._handlers.get(IPC_CHANNELS.TEXT_PREDICTION_SET_ENABLED);
-            await handlerFn!({}, true);
-
-            expect(mockLlmManager.loadModel).toHaveBeenCalled();
-        });
-
-        it('skips V8 sandbox check on macOS', async () => {
-            Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
-            mockApp.commandLine.getSwitchValue.mockReturnValue('');
-            mockLlmManager.isModelDownloaded.mockReturnValue(true);
-            mockDeps.llmNativeAvailable = true;
-            process.env.NODE_ENV = 'production';
-            mockLlmManager.isModelLoaded.mockReturnValue(false);
-            delete process.env.CI;
-
-            const handlerFn = mockIpcMain._handlers.get(IPC_CHANNELS.TEXT_PREDICTION_SET_ENABLED);
-            await handlerFn!({}, true);
-
-            expect(mockLlmManager.loadModel).toHaveBeenCalled();
-        });
-
-        it('skips V8 sandbox check on Windows', async () => {
-            Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-            mockApp.commandLine.getSwitchValue.mockReturnValue('');
-            mockLlmManager.isModelDownloaded.mockReturnValue(true);
-            mockDeps.llmNativeAvailable = true;
-            process.env.NODE_ENV = 'production';
-            mockLlmManager.isModelLoaded.mockReturnValue(false);
-            delete process.env.CI;
-
-            const handlerFn = mockIpcMain._handlers.get(IPC_CHANNELS.TEXT_PREDICTION_SET_ENABLED);
-            await handlerFn!({}, true);
-
-            expect(mockLlmManager.loadModel).toHaveBeenCalled();
-        });
-
-        it('returns requires-restart on Linux when enabled and V8 sandbox active', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            mockApp.commandLine.getSwitchValue.mockReturnValue('');
-            mockStore.get.mockImplementation((key) => {
-                if (key === 'textPredictionEnabled') return true;
-                if (key === 'textPredictionGpuEnabled') return false;
-                if (key === 'textPredictionModelStatus') return 'not-downloaded';
-                return undefined;
-            });
-
-            const handlerFn = mockIpcMain._handlers.get(IPC_CHANNELS.TEXT_PREDICTION_GET_STATUS);
-            const result = (await handlerFn!()) as {
-                status: string;
-                requiresRestart?: boolean;
-                restartReason?: string;
-            };
-
-            expect(result.status).toBe('requires-restart');
-            expect(result.requiresRestart).toBe(true);
-            expect(result.restartReason).toEqual(expect.any(String));
-        });
-
-        it('returns normal status on Linux when V8 sandbox disabled', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            mockApp.commandLine.getSwitchValue.mockReturnValue('--no-v8-sandbox');
-            mockStore.get.mockImplementation((key) => {
-                if (key === 'textPredictionEnabled') return true;
-                if (key === 'textPredictionGpuEnabled') return false;
-                if (key === 'textPredictionModelStatus') return 'ready';
-                return undefined;
-            });
-            mockLlmManager.getStatus.mockReturnValue('ready');
-
-            const handlerFn = mockIpcMain._handlers.get(IPC_CHANNELS.TEXT_PREDICTION_GET_STATUS);
-            const result = (await handlerFn!()) as {
-                status: string;
-                requiresRestart?: boolean;
-                restartReason?: string;
-            };
-
-            expect(result.requiresRestart).not.toBe(true);
-        });
-
-        it('never returns requires-restart on macOS', async () => {
-            Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
-            mockApp.commandLine.getSwitchValue.mockReturnValue('');
-            mockStore.get.mockImplementation((key) => {
-                if (key === 'textPredictionEnabled') return true;
-                if (key === 'textPredictionGpuEnabled') return false;
-                if (key === 'textPredictionModelStatus') return 'ready';
-                return undefined;
-            });
-            mockLlmManager.getStatus.mockReturnValue('ready');
-
-            const handlerFn = mockIpcMain._handlers.get(IPC_CHANNELS.TEXT_PREDICTION_GET_STATUS);
-            const result = (await handlerFn!()) as { requiresRestart?: boolean };
-
-            expect(result.requiresRestart).not.toBe(true);
-        });
-
-        it('never returns requires-restart on Windows', async () => {
-            Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-            mockApp.commandLine.getSwitchValue.mockReturnValue('');
-            mockStore.get.mockImplementation((key) => {
-                if (key === 'textPredictionEnabled') return true;
-                if (key === 'textPredictionGpuEnabled') return false;
-                if (key === 'textPredictionModelStatus') return 'ready';
-                return undefined;
-            });
-            mockLlmManager.getStatus.mockReturnValue('ready');
-
-            const handlerFn = mockIpcMain._handlers.get(IPC_CHANNELS.TEXT_PREDICTION_GET_STATUS);
-            const result = (await handlerFn!()) as { requiresRestart?: boolean };
-
-            expect(result.requiresRestart).not.toBe(true);
         });
     });
 });

--- a/tests/unit/main/ipcManager.test.ts
+++ b/tests/unit/main/ipcManager.test.ts
@@ -1970,10 +1970,9 @@ describe('IpcManager', () => {
             expect(result).toEqual({
                 enabled: true,
                 gpuEnabled: false,
-                status: 'requires-restart',
-                requiresRestart: true,
-                restartReason:
-                    'Text prediction on Linux requires disabling the V8 memory sandbox. This is a security feature that conflicts with the local AI engine. The app needs to restart to apply this change.',
+                status: 'ready',
+                downloadProgress: 100,
+                errorMessage: undefined,
             });
         });
 

--- a/tests/unit/main/llmManager.test.ts
+++ b/tests/unit/main/llmManager.test.ts
@@ -73,10 +73,18 @@ const readFileSync = vi.mocked(readFileSyncFn);
 
 describe('LlmManager', () => {
     let llmManager: LlmManager;
+    let originalPlatform: PropertyDescriptor | undefined;
 
     beforeEach(() => {
         vi.clearAllMocks();
         useFakeTimers();
+
+        // Text prediction is unsupported on Linux (issue #119), and the test
+        // runner itself is Linux. Default these tests to a supported platform
+        // (darwin) so the existing native-availability/load/download paths are
+        // exercised; the dedicated "platform support (Linux)" block overrides it.
+        originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+        Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
 
         // Reset fs mock
         existsSync.mockReturnValue(false);
@@ -100,6 +108,9 @@ describe('LlmManager', () => {
         useRealTimers();
         if (llmManager) {
             llmManager.dispose();
+        }
+        if (originalPlatform) {
+            Object.defineProperty(process, 'platform', originalPlatform);
         }
     });
 
@@ -433,106 +444,67 @@ describe('LlmManager', () => {
             // This is handled internally by the fallback logic
         });
 
-        describe('V8 sandbox error detection', () => {
-            const originalImport = (
-                globalThis as typeof globalThis & { __import__?: (specifier: string) => Promise<unknown> }
-            ).__import__;
-            const originalNodeEnv = process.env.NODE_ENV;
+        it('maps a V8 memory cage error to an accurate not-supported message', async () => {
+            // On a supported platform, if the native engine ever raises the
+            // issue #119 cage error, it must be reported as unsupported (not as
+            // an impossible "disable the sandbox and restart" instruction).
+            process.env.NODE_ENV = 'test';
+            existsSync.mockReturnValue(true);
+            readFileSync.mockReturnValue('{"version":"0.0.0-test"}');
 
-            afterEach(() => {
-                process.argv = process.argv.filter((arg) => arg !== '--test-text-prediction');
-                if (originalNodeEnv === undefined) {
-                    delete process.env.NODE_ENV;
-                } else {
-                    process.env.NODE_ENV = originalNodeEnv;
-                }
-                if (originalImport === undefined) {
-                    delete (globalThis as typeof globalThis & { __import__?: (specifier: string) => Promise<unknown> })
-                        .__import__;
-                } else {
-                    (
-                        globalThis as typeof globalThis & { __import__?: (specifier: string) => Promise<unknown> }
-                    ).__import__ = originalImport;
-                }
-            });
+            _mockGetLlama.mockRejectedValueOnce(
+                new Error(
+                    'Fatal error in V8: v8_ArrayBuffer_NewBackingStore When the V8 Sandbox is enabled, ArrayBuffer backing stores must be allocated inside the sandbox address space.'
+                )
+            );
 
-            it('detects V8 sandbox ArrayBuffer error and provides actionable message', async () => {
-                process.env.NODE_ENV = 'test';
-                process.argv = [...process.argv, '--test-text-prediction'];
-                (
-                    globalThis as typeof globalThis & { __import__?: (specifier: string) => Promise<unknown> }
-                ).__import__ = async (specifier: string) => {
-                    if (specifier === 'node-llama-cpp') {
-                        return {
-                            getLlama: _mockGetLlama,
-                            LlamaCompletion: MockLlamaCompletion,
-                        };
-                    }
-                    throw new Error(`Unexpected import: ${specifier}`);
-                };
-                existsSync.mockReturnValue(true);
-                readFileSync.mockReturnValue('{"version":"0.0.0-test"}');
+            await expect(llmManager.loadModel()).rejects.toThrow(/not supported on Linux/i);
+            expect(llmManager.getStatus()).toBe('error');
+            const message = llmManager.getErrorMessage() ?? '';
+            expect(message).not.toContain('restart');
+            expect(message).not.toContain('V8 Sandbox');
+            expect(message).not.toContain('v8_ArrayBuffer');
+            expect(llmManager.isNativeAvailable()).toBe(false);
+        });
+    });
 
-                _mockGetLlama.mockRejectedValueOnce(
-                    new Error(
-                        'Fatal error in V8: v8_ArrayBuffer_NewBackingStore When the V8 Sandbox is enabled, ArrayBuffer backing stores must be allocated inside the sandbox address space.'
-                    )
-                );
+    // Text prediction is disabled on Linux because node-llama-cpp allocates
+    // ArrayBuffers outside Electron's V8 memory cage (issue #119).
+    describe('platform support (Linux)', () => {
+        beforeEach(() => {
+            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+            // Fresh instance so the native-availability cache reflects Linux.
+            llmManager = new LlmManager();
+        });
 
-                await expect(llmManager.loadModel()).rejects.toThrow('V8 sandbox');
-                expect(llmManager.getStatus()).toBe('error');
-                expect(llmManager.getErrorMessage()).toContain('V8 sandbox');
-                expect(llmManager.isNativeAvailable()).toBe(false);
-            });
+        it('isSupportedOnPlatform() returns false on Linux', () => {
+            expect(llmManager.isSupportedOnPlatform()).toBe(false);
+        });
 
-            it('detects V8 sandbox error variant and suggests restart', async () => {
-                process.env.NODE_ENV = 'test';
-                process.argv = [...process.argv, '--test-text-prediction'];
-                (
-                    globalThis as typeof globalThis & { __import__?: (specifier: string) => Promise<unknown> }
-                ).__import__ = async (specifier: string) => {
-                    if (specifier === 'node-llama-cpp') {
-                        return {
-                            getLlama: _mockGetLlama,
-                            LlamaCompletion: MockLlamaCompletion,
-                        };
-                    }
-                    throw new Error(`Unexpected import: ${specifier}`);
-                };
-                existsSync.mockReturnValue(true);
-                readFileSync.mockReturnValue('{"version":"0.0.0-test"}');
+        it('reports native module unavailable with an accurate Linux message', () => {
+            expect(llmManager.ensureNativeAvailable('test')).toBe(false);
+            expect(llmManager.isNativeAvailable()).toBe(false);
+            const probeError = llmManager.getNativeProbeError() ?? '';
+            expect(probeError).toContain('Linux');
+            // Must not contain the V8 cage crash strings the release E2E guards against.
+            expect(probeError).not.toContain('V8 Sandbox');
+            expect(probeError).not.toContain('v8_ArrayBuffer');
+            expect(probeError).not.toContain('sandbox address space');
+        });
 
-                _mockGetLlama.mockRejectedValueOnce(
-                    new Error('v8_ArrayBuffer_NewBackingStore: sandbox address space violation')
-                );
+        it('loadModel() rejects without ever invoking getLlama on Linux', async () => {
+            existsSync.mockReturnValue(true);
 
-                await expect(llmManager.loadModel()).rejects.toThrow('V8 sandbox');
-                expect(llmManager.getStatus()).toBe('error');
-                expect(llmManager.getErrorMessage()).toContain('restart');
-            });
+            await expect(llmManager.loadModel()).rejects.toThrow(/not supported on Linux/i);
+            expect(llmManager.getStatus()).toBe('error');
+            expect(_mockGetLlama).not.toHaveBeenCalled();
+        });
 
-            it('re-throws non-V8 errors without modification', async () => {
-                process.env.NODE_ENV = 'test';
-                process.argv = [...process.argv, '--test-text-prediction'];
-                (
-                    globalThis as typeof globalThis & { __import__?: (specifier: string) => Promise<unknown> }
-                ).__import__ = async (specifier: string) => {
-                    if (specifier === 'node-llama-cpp') {
-                        return {
-                            getLlama: _mockGetLlama,
-                            LlamaCompletion: MockLlamaCompletion,
-                        };
-                    }
-                    throw new Error(`Unexpected import: ${specifier}`);
-                };
-                existsSync.mockReturnValue(true);
-                readFileSync.mockReturnValue('{"version":"0.0.0-test"}');
+        it('downloadModel() rejects without downloading on Linux', async () => {
+            existsSync.mockReturnValue(false);
 
-                _mockGetLlama.mockRejectedValueOnce(new Error('Cannot find module'));
-
-                await expect(llmManager.loadModel()).rejects.toThrow('Cannot find module');
-                expect(llmManager.getErrorMessage()).toContain('Cannot find module');
-            });
+            await expect(llmManager.downloadModel()).rejects.toThrow(/not supported on Linux/i);
+            expect(mockCreateModelDownloader).not.toHaveBeenCalled();
         });
     });
 

--- a/tests/unit/main/main.test.ts
+++ b/tests/unit/main/main.test.ts
@@ -206,6 +206,8 @@ vi.mock('../../../src/main/managers/notificationManager', () => {
         default: class NotificationManager {
             dispose = vi.fn();
             onResponseComplete = vi.fn();
+            maybeShowLinuxFeatureNotice = vi.fn();
+            showInfoNotification = vi.fn();
             constructor() {
                 return;
             }

--- a/tests/unit/main/managers/notificationManager.test.ts
+++ b/tests/unit/main/managers/notificationManager.test.ts
@@ -890,4 +890,148 @@ describe('NotificationManager', () => {
             expect(failOnceStore.set).toHaveBeenCalledTimes(2);
         });
     });
+
+    // =========================================================================
+    // Generic informational notification
+    // =========================================================================
+    describe('showInfoNotification', () => {
+        it('creates and shows a notification with the given title and body', () => {
+            const manager = new NotificationManager(
+                mockMainWindow,
+                mockBadgeManager,
+                mockStore as any,
+                mockPlatformAdapter
+            );
+
+            manager.showInfoNotification('Title here', 'Body here');
+
+            expect(notificationSpy._instances.length).toBe(1);
+            expect(notificationSpy._instances[0].title).toBe('Title here');
+            expect(notificationSpy._instances[0].body).toBe('Body here');
+            expect(notificationSpy._instances[0].show).toHaveBeenCalled();
+        });
+
+        it('does nothing when notifications are not supported', () => {
+            notificationSpy.isSupported.mockReturnValue(false);
+            const manager = new NotificationManager(
+                mockMainWindow,
+                mockBadgeManager,
+                mockStore as any,
+                mockPlatformAdapter
+            );
+
+            manager.showInfoNotification('Title', 'Body');
+
+            expect(notificationSpy._instances.length).toBe(0);
+        });
+
+        it('does not throw when notification.show() fails', () => {
+            const manager = new NotificationManager(
+                mockMainWindow,
+                mockBadgeManager,
+                mockStore as any,
+                mockPlatformAdapter
+            );
+
+            mockNotification.mockImplementationOnce(function (this: any, options: any) {
+                this.title = options.title;
+                this.body = options.body;
+                this._listeners = new Map<string, NotificationListener>();
+                this.on = vi.fn((event: string, handler: NotificationListener) => {
+                    this._listeners.set(event, handler);
+                    return this;
+                });
+                this.show = vi.fn().mockImplementation(() => {
+                    throw new Error('Show failed');
+                });
+                notificationSpy._instances.push(this);
+                return this;
+            });
+
+            expect(() => manager.showInfoNotification('Title', 'Body')).not.toThrow();
+        });
+    });
+
+    // =========================================================================
+    // One-time Linux feature notice (issue #119)
+    // =========================================================================
+    describe('maybeShowLinuxFeatureNotice (issue #119)', () => {
+        it('shows the notice once and persists the app version', () => {
+            mockStore = createMockStore({ responseNotificationsEnabled: true });
+            const manager = new NotificationManager(
+                mockMainWindow,
+                mockBadgeManager,
+                mockStore as any,
+                mockPlatformAdapter
+            );
+
+            manager.maybeShowLinuxFeatureNotice({ isWayland: true, appVersion: '1.2.3' });
+
+            expect(notificationSpy._instances.length).toBe(1);
+            expect(mockStore.set).toHaveBeenCalledWith('linuxFeatureNoticeShownForVersion', '1.2.3');
+        });
+
+        it('does not show again for the same app version', () => {
+            mockStore = createMockStore({ linuxFeatureNoticeShownForVersion: '1.2.3' });
+            const manager = new NotificationManager(
+                mockMainWindow,
+                mockBadgeManager,
+                mockStore as any,
+                mockPlatformAdapter
+            );
+
+            manager.maybeShowLinuxFeatureNotice({ isWayland: true, appVersion: '1.2.3' });
+
+            expect(notificationSpy._instances.length).toBe(0);
+            expect(mockStore.set).not.toHaveBeenCalled();
+        });
+
+        it('shows again after the app version changes', () => {
+            mockStore = createMockStore({ linuxFeatureNoticeShownForVersion: '1.0.0' });
+            const manager = new NotificationManager(
+                mockMainWindow,
+                mockBadgeManager,
+                mockStore as any,
+                mockPlatformAdapter
+            );
+
+            manager.maybeShowLinuxFeatureNotice({ isWayland: true, appVersion: '2.0.0' });
+
+            expect(notificationSpy._instances.length).toBe(1);
+            expect(mockStore.set).toHaveBeenCalledWith('linuxFeatureNoticeShownForVersion', '2.0.0');
+        });
+
+        it('mentions both global hotkeys and text prediction on Wayland', () => {
+            mockStore = createMockStore({});
+            const manager = new NotificationManager(
+                mockMainWindow,
+                mockBadgeManager,
+                mockStore as any,
+                mockPlatformAdapter
+            );
+
+            manager.maybeShowLinuxFeatureNotice({ isWayland: true, appVersion: '1.0.0' });
+
+            const body = notificationSpy._instances[0].body as string;
+            expect(body).toContain('Global hotkeys');
+            expect(body.toLowerCase()).toContain('text prediction');
+            expect(body).toContain('#119');
+        });
+
+        it('mentions only text prediction on X11', () => {
+            mockStore = createMockStore({});
+            const manager = new NotificationManager(
+                mockMainWindow,
+                mockBadgeManager,
+                mockStore as any,
+                mockPlatformAdapter
+            );
+
+            manager.maybeShowLinuxFeatureNotice({ isWayland: false, appVersion: '1.0.0' });
+
+            const body = notificationSpy._instances[0].body as string;
+            expect(body).not.toContain('Global hotkeys');
+            expect(body.toLowerCase()).toContain('text prediction');
+        });
+    });
 });

--- a/tests/unit/main/platform/linuxAdapters.test.ts
+++ b/tests/unit/main/platform/linuxAdapters.test.ts
@@ -191,12 +191,17 @@ describe('LinuxWaylandAdapter', () => {
     });
 
     describe('getHotkeyRegistrationPlan()', () => {
-        it('should return mode "wayland-dbus" when portal available', () => {
+        // The Wayland D-Bus portal path depends on dbus-next/usocket, which is
+        // incompatible with Electron's V8 memory cage and crashes at startup
+        // (issue #119). The plan is force-disabled even when the portal is
+        // available, while still surfacing the real Wayland status for
+        // diagnostics and the user-facing notice.
+        it('should return mode "disabled" even when portal available (issue #119)', () => {
             mockGetWaylandPlatformStatus.mockReturnValue(WAYLAND_PORTAL_AVAILABLE);
 
             const plan = adapter.getHotkeyRegistrationPlan();
 
-            expect(plan.mode).toBe('wayland-dbus');
+            expect(plan.mode).toBe('disabled');
             expect(plan.waylandStatus).toEqual(WAYLAND_PORTAL_AVAILABLE);
         });
 
@@ -207,6 +212,14 @@ describe('LinuxWaylandAdapter', () => {
 
             expect(plan.mode).toBe('disabled');
             expect(plan.waylandStatus).toEqual(WAYLAND_PORTAL_UNAVAILABLE);
+        });
+
+        it('should never resolve to wayland-dbus on Wayland Linux (issue #119)', () => {
+            mockGetWaylandPlatformStatus.mockReturnValue(WAYLAND_PORTAL_AVAILABLE);
+
+            const plan = adapter.getHotkeyRegistrationPlan();
+
+            expect(plan.mode).not.toBe('wayland-dbus');
         });
     });
 

--- a/tests/unit/main/sandboxInit.test.ts
+++ b/tests/unit/main/sandboxInit.test.ts
@@ -1,8 +1,14 @@
 /**
  * Unit tests for sandboxInit side-effect module.
  *
- * Tests that the sandbox initialization correctly sets the no-sandbox
+ * Tests that the sandbox initialization correctly sets the Chromium no-sandbox
  * command line switch when running on restricted Linux systems.
+ *
+ * NOTE: This module intentionally never touches the V8 sandbox / V8 memory
+ * cage. That cage is compile-time and cannot be disabled at runtime, so the
+ * old V8 js-flag mitigation has been removed (issue #119). The Linux startup
+ * crash is mitigated by not loading the offending native modules (see
+ * hotkeyManager/dbusFallback and llmManager), not by a launch flag.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
@@ -68,165 +74,22 @@ describe('sandboxInit', () => {
         expect(app.commandLine.appendSwitch).not.toHaveBeenCalled();
     });
 
-    describe('V8 sandbox mitigation (Linux text prediction)', () => {
-        it('applies --no-v8-sandbox on Linux when --test-text-prediction flag is set', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            const originalArgv = process.argv;
-            process.argv = [...originalArgv, '--test-text-prediction'];
+    it('never appends a js-flags switch on Linux (V8 cage is not touched, issue #119)', async () => {
+        Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+        const { shouldDisableSandbox } = await import('../../../src/main/utils/sandboxDetector');
+        vi.mocked(shouldDisableSandbox).mockReturnValue(true);
 
-            try {
-                const { shouldDisableSandbox } = await import('../../../src/main/utils/sandboxDetector');
-                vi.mocked(shouldDisableSandbox).mockReturnValue(false);
+        const { readFileSync } = await import('fs');
+        // Even if settings.json says text prediction is enabled, no js-flags must be set.
+        vi.mocked(readFileSync).mockReturnValue('{"textPredictionEnabled": true}');
 
-                const { readFileSync } = await import('fs');
-                vi.mocked(readFileSync).mockImplementation(() => {
-                    const error = new Error('ENOENT') as NodeJS.ErrnoException;
-                    error.code = 'ENOENT';
-                    throw error;
-                });
+        await import('../../../src/main/utils/sandboxInit');
 
-                await import('../../../src/main/utils/sandboxInit');
-
-                const { app } = await import('electron');
-                expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('js-flags', '--no-v8-sandbox');
-            } finally {
-                process.argv = originalArgv;
-            }
-        });
-
-        it('applies --no-v8-sandbox on Linux when textPredictionEnabled is true in settings', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            const { shouldDisableSandbox } = await import('../../../src/main/utils/sandboxDetector');
-            vi.mocked(shouldDisableSandbox).mockReturnValue(false);
-
-            const { readFileSync } = await import('fs');
-            vi.mocked(readFileSync).mockReturnValue('{"textPredictionEnabled": true}');
-
-            await import('../../../src/main/utils/sandboxInit');
-
-            const { app } = await import('electron');
-            expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('js-flags', '--no-v8-sandbox');
-        });
-
-        it('does NOT apply --no-v8-sandbox on macOS even when textPredictionEnabled is true', async () => {
-            Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
-            const { shouldDisableSandbox } = await import('../../../src/main/utils/sandboxDetector');
-            vi.mocked(shouldDisableSandbox).mockReturnValue(false);
-
-            const { readFileSync } = await import('fs');
-            vi.mocked(readFileSync).mockReturnValue('{"textPredictionEnabled": true}');
-
-            await import('../../../src/main/utils/sandboxInit');
-
-            const { app } = await import('electron');
-            expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith('js-flags', '--no-v8-sandbox');
-        });
-
-        it('does NOT apply --no-v8-sandbox on Windows even when textPredictionEnabled is true', async () => {
-            Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-            const { shouldDisableSandbox } = await import('../../../src/main/utils/sandboxDetector');
-            vi.mocked(shouldDisableSandbox).mockReturnValue(false);
-
-            const { readFileSync } = await import('fs');
-            vi.mocked(readFileSync).mockReturnValue('{"textPredictionEnabled": true}');
-
-            await import('../../../src/main/utils/sandboxInit');
-
-            const { app } = await import('electron');
-            expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith('js-flags', '--no-v8-sandbox');
-        });
-
-        it('does NOT apply --no-v8-sandbox when textPredictionEnabled is false', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            const { shouldDisableSandbox } = await import('../../../src/main/utils/sandboxDetector');
-            vi.mocked(shouldDisableSandbox).mockReturnValue(false);
-
-            const { readFileSync } = await import('fs');
-            vi.mocked(readFileSync).mockReturnValue('{"textPredictionEnabled": false}');
-
-            await import('../../../src/main/utils/sandboxInit');
-
-            const { app } = await import('electron');
-            expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith('js-flags', '--no-v8-sandbox');
-        });
-
-        it('does NOT apply --no-v8-sandbox when textPredictionEnabled is missing', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            const { shouldDisableSandbox } = await import('../../../src/main/utils/sandboxDetector');
-            vi.mocked(shouldDisableSandbox).mockReturnValue(false);
-
-            const { readFileSync } = await import('fs');
-            vi.mocked(readFileSync).mockReturnValue('{"theme": "dark"}');
-
-            await import('../../../src/main/utils/sandboxInit');
-
-            const { app } = await import('electron');
-            expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith('js-flags', '--no-v8-sandbox');
-        });
-
-        it('handles missing settings file gracefully (ENOENT)', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            const { shouldDisableSandbox } = await import('../../../src/main/utils/sandboxDetector');
-            vi.mocked(shouldDisableSandbox).mockReturnValue(false);
-
-            const { readFileSync } = await import('fs');
-            vi.mocked(readFileSync).mockImplementation(() => {
-                const error = new Error('ENOENT') as NodeJS.ErrnoException;
-                error.code = 'ENOENT';
-                throw error;
-            });
-
-            await import('../../../src/main/utils/sandboxInit');
-
-            const { app } = await import('electron');
-            expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith('js-flags', '--no-v8-sandbox');
-        });
-
-        it('handles corrupt settings file gracefully (invalid JSON)', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            const { shouldDisableSandbox } = await import('../../../src/main/utils/sandboxDetector');
-            vi.mocked(shouldDisableSandbox).mockReturnValue(false);
-
-            const { readFileSync } = await import('fs');
-            vi.mocked(readFileSync).mockReturnValue('not-json');
-
-            await import('../../../src/main/utils/sandboxInit');
-
-            const { app } = await import('electron');
-            expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith('js-flags', '--no-v8-sandbox');
-        });
-
-        it('handles permission error gracefully', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            const { shouldDisableSandbox } = await import('../../../src/main/utils/sandboxDetector');
-            vi.mocked(shouldDisableSandbox).mockReturnValue(false);
-
-            const { readFileSync } = await import('fs');
-            vi.mocked(readFileSync).mockImplementation(() => {
-                const error = new Error('EACCES') as NodeJS.ErrnoException;
-                error.code = 'EACCES';
-                throw error;
-            });
-
-            await import('../../../src/main/utils/sandboxInit');
-
-            const { app } = await import('electron');
-            expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith('js-flags', '--no-v8-sandbox');
-        });
-
-        it('applies BOTH Chromium sandbox and V8 sandbox flags when both conditions are met', async () => {
-            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-            const { shouldDisableSandbox } = await import('../../../src/main/utils/sandboxDetector');
-            vi.mocked(shouldDisableSandbox).mockReturnValue(true);
-
-            const { readFileSync } = await import('fs');
-            vi.mocked(readFileSync).mockReturnValue('{"textPredictionEnabled": true}');
-
-            await import('../../../src/main/utils/sandboxInit');
-
-            const { app } = await import('electron');
-            expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('no-sandbox');
-            expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('js-flags', '--no-v8-sandbox');
-        });
+        const { app } = await import('electron');
+        const appendCalls = vi.mocked(app.commandLine.appendSwitch).mock.calls;
+        // Chromium no-sandbox is still allowed; js-flags must never be appended.
+        expect(appendCalls.some(([flag]) => flag === 'js-flags')).toBe(false);
+        // settings.json must not even be read anymore.
+        expect(readFileSync).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/main/utils/dbusFallback.test.ts
+++ b/tests/unit/main/utils/dbusFallback.test.ts
@@ -99,6 +99,7 @@ vi.mock('dbus-next', () => ({
 
 describe('DBusFallback', () => {
     let dbusFallback: typeof import('../../../../src/main/utils/dbusFallback');
+    let originalPlatform: PropertyDescriptor | undefined;
 
     /**
      * Set up fresh mocks and module before each test.
@@ -108,6 +109,13 @@ describe('DBusFallback', () => {
         vi.clearAllMocks();
         mockSessionBusCalls.length = 0;
         busMessageHandlers = [];
+
+        // The module now refuses to import dbus-next/usocket on Linux (the V8
+        // memory cage / issue #119 guard), and the test runner is Linux. Default
+        // to a non-Linux platform so the mocked D-Bus flow is exercised; the
+        // dedicated "Linux V8 cage guard" block overrides this back to linux.
+        originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+        Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
 
         // Set up default mock implementations
         mockGetInterface.mockImplementation((iface: string) => {
@@ -177,6 +185,41 @@ describe('DBusFallback', () => {
         } catch {
             // Ignore cleanup errors
         }
+        if (originalPlatform) {
+            Object.defineProperty(process, 'platform', originalPlatform);
+        }
+    });
+
+    // ========================================================================
+    // Linux V8 cage guard (issue #119)
+    // ========================================================================
+    // dbus-next pulls in the native `usocket` addon, which allocates ArrayBuffers
+    // outside Electron's V8 memory cage and FATAL-aborts the process on Linux.
+    // The module must never import dbus-next on Linux.
+
+    describe('Linux V8 cage guard (issue #119)', () => {
+        beforeEach(() => {
+            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+        });
+
+        it('isDBusFallbackAvailable() returns false without importing dbus-next on Linux', async () => {
+            const available = await dbusFallback.isDBusFallbackAvailable();
+
+            expect(available).toBe(false);
+            // dbus-next must never be imported / sessionBus never created on Linux.
+            expect(mockSessionBusCalls.length).toBe(0);
+        });
+
+        it('registerViaDBus() reports failure without importing dbus-next on Linux', async () => {
+            const results = await dbusFallback.registerViaDBus([
+                { id: 'quickChat', accelerator: 'CommandOrControl+Shift+Space', description: 'Quick Chat' },
+            ]);
+
+            expect(mockSessionBusCalls.length).toBe(0);
+            expect(results).toHaveLength(1);
+            expect(results[0]?.success).toBe(false);
+            expect(results[0]?.error).toBeTruthy();
+        });
     });
 
     // ========================================================================

--- a/tests/unit/renderer/TextPredictionSettings.test.tsx
+++ b/tests/unit/renderer/TextPredictionSettings.test.tsx
@@ -14,12 +14,15 @@ import '@testing-library/jest-dom/vitest';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { TextPredictionSettings } from '../../../src/renderer/components/options/TextPredictionSettings';
+import { isLinux } from '../../../src/renderer/utils/platform';
 import { setupMockElectronAPI } from '../../helpers/mocks';
 
-// Mock platform utils
+// Mock platform utils. isLinux defaults to false (non-Linux); the Linux block
+// overrides it to exercise the "unavailable on Linux" UI (issue #119).
 vi.mock('../../../src/renderer/utils/platform', () => ({
     isDevMode: vi.fn().mockReturnValue(false),
     getIsDev: vi.fn().mockReturnValue(false),
+    isLinux: vi.fn().mockReturnValue(false),
 }));
 
 describe('TextPredictionSettings', () => {
@@ -29,7 +32,6 @@ describe('TextPredictionSettings', () => {
     const mockSetTextPredictionGpuEnabled = vi.fn();
     const mockOnTextPredictionStatusChanged = vi.fn();
     const mockOnTextPredictionDownloadProgress = vi.fn();
-    const mockRestartApp = vi.fn();
 
     beforeEach(() => {
         vi.clearAllMocks();
@@ -44,7 +46,9 @@ describe('TextPredictionSettings', () => {
         mockSetTextPredictionGpuEnabled.mockResolvedValue(undefined);
         mockOnTextPredictionStatusChanged.mockReturnValue(() => {});
         mockOnTextPredictionDownloadProgress.mockReturnValue(() => {});
-        mockRestartApp.mockResolvedValue(undefined);
+
+        // Default to non-Linux so the standard UI renders; Linux block overrides.
+        vi.mocked(isLinux).mockReturnValue(false);
 
         // Use shared factory with test-specific overrides
         setupMockElectronAPI({
@@ -53,7 +57,6 @@ describe('TextPredictionSettings', () => {
             setTextPredictionGpuEnabled: mockSetTextPredictionGpuEnabled,
             onTextPredictionStatusChanged: mockOnTextPredictionStatusChanged,
             onTextPredictionDownloadProgress: mockOnTextPredictionDownloadProgress,
-            restartApp: mockRestartApp,
         });
     });
 
@@ -385,110 +388,72 @@ describe('TextPredictionSettings', () => {
         });
     });
 
-    describe('Restart Notice', () => {
-        it('shows restart notice when status is requires-restart', async () => {
+    describe('Linux (text prediction unavailable, issue #119)', () => {
+        beforeEach(() => {
+            vi.mocked(isLinux).mockReturnValue(true);
+        });
+
+        afterEach(() => {
+            vi.mocked(isLinux).mockReturnValue(false);
+        });
+
+        it('shows the unavailable notice on Linux', async () => {
             mockGetTextPredictionStatus.mockResolvedValue({
-                enabled: true,
+                enabled: false,
                 gpuEnabled: false,
-                status: 'requires-restart',
-                requiresRestart: true,
-                restartReason: 'Text prediction on Linux requires disabling the V8 memory sandbox.',
+                status: 'not-downloaded',
             });
 
             render(<TextPredictionSettings />);
 
             await waitFor(() => {
-                expect(screen.getByTestId('text-prediction-restart-notice')).toBeInTheDocument();
+                expect(screen.getByTestId('text-prediction-linux-unavailable')).toBeInTheDocument();
             });
         });
 
-        it('displays the restart reason text', async () => {
-            const reason = 'Text prediction on Linux requires disabling the V8 memory sandbox.';
+        it('explains why and references the tracking issue', async () => {
+            render(<TextPredictionSettings />);
+
+            const notice = await screen.findByTestId('text-prediction-linux-unavailable');
+            expect(notice).toHaveTextContent(/Unavailable on Linux/i);
+            expect(notice).toHaveTextContent(/#119/);
+        });
+
+        it('renders the enable toggle as disabled on Linux', async () => {
+            render(<TextPredictionSettings />);
+
+            const toggle = await screen.findByTestId('text-prediction-enable-toggle-switch');
+            expect(toggle).toBeDisabled();
+        });
+
+        it('does not call setTextPredictionEnabled when the disabled toggle is clicked', async () => {
+            render(<TextPredictionSettings />);
+
+            const toggle = await screen.findByTestId('text-prediction-enable-toggle-switch');
+            fireEvent.click(toggle);
+
+            expect(mockSetTextPredictionEnabled).not.toHaveBeenCalled();
+        });
+
+        it('hides the GPU toggle and status indicator on Linux', async () => {
             mockGetTextPredictionStatus.mockResolvedValue({
                 enabled: true,
                 gpuEnabled: false,
-                status: 'requires-restart',
-                requiresRestart: true,
-                restartReason: reason,
+                status: 'ready',
             });
 
             render(<TextPredictionSettings />);
 
             await waitFor(() => {
-                expect(screen.getByText(reason)).toBeInTheDocument();
-            });
-        });
-
-        it('displays Restart Now button', async () => {
-            mockGetTextPredictionStatus.mockResolvedValue({
-                enabled: true,
-                gpuEnabled: false,
-                status: 'requires-restart',
-                requiresRestart: true,
-                restartReason: 'Needs restart',
-            });
-
-            render(<TextPredictionSettings />);
-
-            await waitFor(() => {
-                expect(screen.getByTestId('text-prediction-restart-button')).toBeInTheDocument();
-            });
-        });
-
-        it('calls restartApp when Restart Now button is clicked', async () => {
-            mockGetTextPredictionStatus.mockResolvedValue({
-                enabled: true,
-                gpuEnabled: false,
-                status: 'requires-restart',
-                requiresRestart: true,
-                restartReason: 'Needs restart',
-            });
-
-            render(<TextPredictionSettings />);
-
-            const restartBtn = await screen.findByTestId('text-prediction-restart-button');
-            fireEvent.click(restartBtn);
-
-            expect(mockRestartApp).toHaveBeenCalled();
-        });
-
-        it('hides GPU toggle when restart is required', async () => {
-            mockGetTextPredictionStatus.mockResolvedValue({
-                enabled: true,
-                gpuEnabled: false,
-                status: 'requires-restart',
-                requiresRestart: true,
-                restartReason: 'Needs restart',
-            });
-
-            render(<TextPredictionSettings />);
-
-            await waitFor(() => {
-                expect(screen.getByTestId('text-prediction-restart-notice')).toBeInTheDocument();
+                expect(screen.getByTestId('text-prediction-linux-unavailable')).toBeInTheDocument();
             });
 
             expect(screen.queryByTestId('text-prediction-gpu-toggle')).not.toBeInTheDocument();
-        });
-
-        it('hides status indicator when restart is required', async () => {
-            mockGetTextPredictionStatus.mockResolvedValue({
-                enabled: true,
-                gpuEnabled: false,
-                status: 'requires-restart',
-                requiresRestart: true,
-                restartReason: 'Needs restart',
-            });
-
-            render(<TextPredictionSettings />);
-
-            await waitFor(() => {
-                expect(screen.getByTestId('text-prediction-restart-notice')).toBeInTheDocument();
-            });
-
             expect(screen.queryByTestId('text-prediction-status')).not.toBeInTheDocument();
         });
 
-        it('does NOT show restart notice for normal statuses', async () => {
+        it('does NOT show the unavailable notice on non-Linux platforms', async () => {
+            vi.mocked(isLinux).mockReturnValue(false);
             mockGetTextPredictionStatus.mockResolvedValue({
                 enabled: true,
                 gpuEnabled: false,
@@ -501,7 +466,7 @@ describe('TextPredictionSettings', () => {
                 expect(screen.getByTestId('text-prediction-settings')).toBeInTheDocument();
             });
 
-            expect(screen.queryByTestId('text-prediction-restart-notice')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('text-prediction-linux-unavailable')).not.toBeInTheDocument();
         });
     });
 


### PR DESCRIPTION
## Summary

Fixes the fatal startup crash on Linux (Fedora 43 / KDE Plasma 6 Wayland, CachyOS, etc.):

```
Fatal error in V8: v8_ArrayBuffer_NewBackingStore — When the V8 Sandbox is enabled,
ArrayBuffer backing stores must be allocated inside the sandbox address space ...
Segmentation fault (core dumped)
```

Closes the crash reported in #119.

## Root cause (cage vs. native ArrayBuffer — **not** kernel)

Electron's **V8 sandbox / V8 memory cage** has been ON by default since Electron 21 (this app is on Electron 39). When the cage is on, **any native addon that allocates an ArrayBuffer backing store *outside* the cage makes V8 `FATAL`-abort the whole process.** Refs: [V8 memory cage](https://www.electronjs.org/blog/v8-memory-cage), [electron/electron#37790](https://github.com/electron/electron/issues/37790).

Two native addons in this app do exactly that:

| Addon | Pulled in by | Used on |
| --- | --- | --- |
| `usocket` | `dbus-next` | the **Wayland** global-shortcut path (D-Bus auth handshake) |
| `node-llama-cpp` | local text prediction | the text-prediction feature (off by default) |

The crash stack is inside `usocket._write`, reached via `hotkeyManager → registerViaDBus → dbus-next` while registering Wayland global shortcuts — which is why Wayland users hit it on launch.

This is **not** kernel-related. The kernel‑7 correlation is a false signal: #119's reporter is on Fedora 43 (a **6.x** kernel). The real common factor is *"the cage is on **and** a cage-incompatible native code path runs."*

There is also **no runtime switch** to turn the cage off — it is compile-time. `--js-flags=--no-v8-sandbox` has no effect (V8 literally prints `unrecognized flag`), and the failure is a C++ `FATAL`/`SIGSEGV`, not a catchable JS error. So the previous kernel‑gated / `--no-v8-sandbox` approach could never have worked.

## What this PR does

The V8 cage stays **enabled** (no security regression). Instead, we stop loading the two cage-incompatible modules on Linux and tell the user.

1. **Removed all dead "disable V8 sandbox" code**
   - `sandboxInit.ts`: dropped the `js-flags` / `--no-v8-sandbox` switch, the `settings.json` text-prediction read, and the `--test-text-prediction` path. Kept the unrelated Chromium `no-sandbox` (AppImage) switch.
   - `TextPredictionIpcHandler.ts`: removed the `--no-v8-sandbox` / `requires-restart` logic that assumed a restart-with-flag could enable the feature.
   - `llmManager.ts`: replaced the impossible *"disable the V8 memory sandbox and restart"* error message with accurate *"not supported on Linux in this build"* messaging.
   - Removed the now-dead `requires-restart` status and `requiresRestart`/`restartReason` fields, and the restart UI.

2. **Disabled the Wayland global-shortcut (dbus-next/usocket) path on Linux**
   - `LinuxWaylandAdapter.getHotkeyRegistrationPlan()` now resolves to `disabled` instead of `wayland-dbus`, so `registerViaDBus` / `isDBusFallbackAvailable` / `await import('dbus-next')` are never reached.
   - Added a defense-in-depth guard at the `dbus-next` dynamic-import sites in `dbusFallback.ts`.
   - **X11** uses Electron's native `globalShortcut` (no `usocket`) and is untouched.

3. **Disabled text prediction (node-llama-cpp) on Linux**
   - Added `LlmManager.isSupportedOnPlatform()` (false on Linux); `isNativeAvailable()`/`ensureNativeAvailable()` reflect it, so `loadModel()` / `getLlama()` are never invoked on Linux.
   - Text-prediction settings UI now shows the feature as **disabled/unavailable on Linux** with a short explanation, instead of letting a user enable it and crash.

4. **User-facing notification (the primary deliverable)**
   - After app ready + main window created, on Linux, shows **one** notification (reusing the existing Wayland detection):
     - **Wayland:** covers *both* global hotkeys and text prediction.
     - **X11:** covers text prediction only.
   - Shown **at most once per app version** (persisted as `linuxFeatureNoticeShownForVersion`), via a new `NotificationManager.showInfoNotification()` / `maybeShowLinuxFeatureNotice()` (failures contained in `try/catch`).

## Supersedes #333

This replaces the unmerged **#333** ("fix(linux): disable V8 sandbox on incompatible kernels (7.x+)"), whose kernel-gated `--no-v8-sandbox` approach is a dead end (the cage can't be disabled at runtime, and #119's reporter is on a 6.x kernel that #333's `kernel >= 7` gate skips). **#333 should be closed in favor of this PR.**

## Out of scope (proper follow-up)

Restoring these features *with the cage on* means:
- replacing the native `usocket` transport in the D-Bus path with a Node `net`-based unix-socket transport, and
- running `node-llama-cpp` out of the cage (e.g. utility process).

Both are out of scope for this hotfix.

## Acceptance / verification

- No occurrence of `--no-v8-sandbox` or kernel-version sandbox logic remains anywhere in `src/` or `tests/`.
- `dbus-next`/`usocket` is never imported on Linux; text prediction never loads `node-llama-cpp` on Linux.
- Added unit tests for: the Wayland hotkey plan resolving to `disabled` (issue #119), text prediction reported unsupported on Linux, the `dbus-next` import guard, and the notification firing once per app version.
- Typecheck (renderer + electron), lint, and the test suites all pass locally:
  - renderer **650 passed** (4 skipped) · electron **1848 passed** · coordinated **848 passed**

> Note: the actual segfault can't be reproduced in CI/sandboxed dev (no Wayland session bus + portal), so runtime confirmation on a real Wayland KDE machine (Fedora 43 / CachyOS) is still recommended before closing #119.