### PR TITLE
chore: release v0.12.1

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,6 +5,12 @@ Priorities may shift based on user feedback, upstream Gemini changes, and platfo
 
 ## Recently Shipped
 
+### v0.12.1 — Linux Stability & Maintenance
+
+- **Linux startup stability** — avoid loading V8-sandbox-incompatible native probes on affected Linux kernels so the app can launch reliably while preserving in-app keyboard shortcuts; global hotkeys and local text prediction remain unavailable on those kernel paths. ([#333](https://github.com/bwendell/gemini-desktop/pull/333))
+- **Linux package metadata refresh** — remove deprecated Debian dependencies, recommend Ayatana AppIndicator support, and document current appindicator guidance for modern Linux distributions. ([#332](https://github.com/bwendell/gemini-desktop/pull/332))
+- **Maintenance updates** — refresh post-`v0.12.0` runtime, Electron, testing, React type, YAML, CodeQL, and markdown-rendering dependencies. ([#309](https://github.com/bwendell/gemini-desktop/pull/309), [#314](https://github.com/bwendell/gemini-desktop/pull/314), [#320](https://github.com/bwendell/gemini-desktop/pull/320), [#338](https://github.com/bwendell/gemini-desktop/pull/338), [#339](https://github.com/bwendell/gemini-desktop/pull/339), [#340](https://github.com/bwendell/gemini-desktop/pull/340), [#342](https://github.com/bwendell/gemini-desktop/pull/342), [#344](https://github.com/bwendell/gemini-desktop/pull/344), [#345](https://github.com/bwendell/gemini-desktop/pull/345), [#347](https://github.com/bwendell/gemini-desktop/pull/347), [#348](https://github.com/bwendell/gemini-desktop/pull/348))
+
 ### v0.12.0 — Chat Flow & Release Reliability
 
 - **Chat workflow upgrades** — add Smart Enter's upload-aware submission queue and a floating scroll-to-bottom control, both with persisted settings toggles for smoother long-running Gemini chats. ([#321](https://github.com/bwendell/gemini-desktop/pull/321))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gemini-desktop",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gemini-desktop",
-            "version": "0.12.0",
+            "version": "0.12.1",
             "dependencies": {
                 "dbus-next": "^0.10.2",
                 "electron-log": "^5.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
                 "@wdio/types": "^9.23.3",
                 "concurrently": "^9.2.1",
                 "electron": "^39.8.10",
-                "electron-builder": "^26.15.2",
+                "electron-builder": "26.8.1",
                 "eslint": "^9.39.2",
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-plugin-react": "^7.37.5",
@@ -596,6 +596,24 @@
             "license": "MIT",
             "engines": {
                 "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@develar/schema-utils": {
+            "version": "2.6.5",
+            "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+            "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^6.12.0",
+                "ajv-keywords": "^3.4.1"
+            },
+            "engines": {
+                "node": ">= 8.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/@electron/asar": {
@@ -2868,6 +2886,8 @@
             "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 20.19.0"
             },
@@ -3107,58 +3127,6 @@
             "license": "MIT/X11",
             "engines": {
                 "node": ">=0.3.0"
-            }
-        },
-        "node_modules/@peculiar/asn1-schema": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
-            "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@peculiar/utils": "^2.0.2",
-                "asn1js": "^3.0.6",
-                "tslib": "^2.8.1"
-            }
-        },
-        "node_modules/@peculiar/json-schema": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-            "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/@peculiar/utils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
-            "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.8.1"
-            }
-        },
-        "node_modules/@peculiar/webcrypto": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
-            "integrity": "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@peculiar/asn1-schema": "^2.7.0",
-                "@peculiar/json-schema": "^1.1.12",
-                "@peculiar/utils": "^2.0.2",
-                "tslib": "^2.8.1",
-                "webcrypto-core": "^1.9.2"
-            },
-            "engines": {
-                "node": ">=14.18.0"
             }
         },
         "node_modules/@pkgjs/parseargs": {
@@ -4172,6 +4140,18 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/plist": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
+            "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@types/node": "*",
+                "xmlbuilder": ">=11.0.1"
+            }
+        },
         "node_modules/@types/react": {
             "version": "19.2.17",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -4236,6 +4216,14 @@
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/verror": {
+            "version": "1.10.11",
+            "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
+            "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/@types/which": {
             "version": "2.0.2",
@@ -5583,6 +5571,13 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/7zip-bin": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+            "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/abbrev": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
@@ -5654,6 +5649,16 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-keywords": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "ajv": "^6.9.1"
             }
         },
         "node_modules/ansi-colors": {
@@ -5732,36 +5737,40 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/app-builder-bin": {
+            "version": "5.0.0-alpha.12",
+            "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz",
+            "integrity": "sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/app-builder-lib": {
-            "version": "26.15.2",
-            "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.2.tgz",
-            "integrity": "sha512-3mYfKOjr/ZY7gFESOcq8kylBMgGPpmlQYnpBVit4p6zIg0t/8bkWBILdMMtnjFyN2jllyBf225T8dLlz3D6oBQ==",
+            "version": "26.8.1",
+            "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.8.1.tgz",
+            "integrity": "sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "@develar/schema-utils": "~2.6.5",
                 "@electron/asar": "3.4.1",
                 "@electron/fuses": "^1.8.0",
                 "@electron/get": "^3.0.0",
                 "@electron/notarize": "2.5.0",
                 "@electron/osx-sign": "1.3.3",
-                "@electron/rebuild": "^4.0.4",
+                "@electron/rebuild": "^4.0.3",
                 "@electron/universal": "2.0.3",
                 "@malept/flatpak-bundler": "^0.4.0",
-                "@noble/hashes": "^2.2.0",
-                "@peculiar/webcrypto": "^1.7.1",
                 "@types/fs-extra": "9.0.13",
-                "ajv": "^8.18.0",
-                "asn1js": "^3.0.10",
                 "async-exit-hook": "^2.0.1",
-                "builder-util": "26.15.0",
-                "builder-util-runtime": "9.7.0",
+                "builder-util": "26.8.1",
+                "builder-util-runtime": "9.5.1",
                 "chromium-pickle-js": "^0.2.0",
                 "ci-info": "4.3.1",
                 "debug": "^4.3.4",
                 "dotenv": "^16.4.5",
                 "dotenv-expand": "^11.0.6",
                 "ejs": "^3.1.8",
-                "electron-publish": "26.15.1",
+                "electron-publish": "26.8.1",
                 "fs-extra": "^10.1.0",
                 "hosted-git-info": "^4.1.0",
                 "isbinaryfile": "^5.0.0",
@@ -5769,8 +5778,7 @@
                 "js-yaml": "^4.1.0",
                 "json5": "^2.2.3",
                 "lazy-val": "^1.0.5",
-                "minimatch": "^10.2.5",
-                "pkijs": "^3.4.0",
+                "minimatch": "^10.0.3",
                 "plist": "3.1.0",
                 "proper-lockfile": "^4.1.2",
                 "resedit": "^1.7.0",
@@ -5778,15 +5786,14 @@
                 "tar": "^7.5.7",
                 "temp-file": "^3.4.0",
                 "tiny-async-pool": "1.3.0",
-                "unzipper": "^0.12.3",
                 "which": "^5.0.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             },
             "peerDependencies": {
-                "dmg-builder": "26.15.2",
-                "electron-builder-squirrel-windows": "26.15.2"
+                "dmg-builder": "26.8.1",
+                "electron-builder-squirrel-windows": "26.8.1"
             }
         },
         "node_modules/app-builder-lib/node_modules/@electron/get": {
@@ -5834,50 +5841,6 @@
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/app-builder-lib/node_modules/ajv": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/app-builder-lib/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/app-builder-lib/node_modules/builder-util-runtime": {
-            "version": "9.7.0",
-            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
-            "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4",
-                "sax": "^1.2.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
             }
         },
         "node_modules/app-builder-lib/node_modules/ci-info": {
@@ -5955,29 +5918,6 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/app-builder-lib/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/app-builder-lib/node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "brace-expansion": "^5.0.5"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/app-builder-lib/node_modules/semver": {
@@ -6298,19 +6238,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/asn1js": {
-            "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
-            "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+        "node_modules/assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "pvtsutils": "^1.3.6",
-                "pvutils": "^1.1.5",
-                "tslib": "^2.8.1"
-            },
+            "license": "MIT",
+            "optional": true,
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=0.8"
             }
         },
         "node_modules/assertion-error": {
@@ -6354,6 +6290,17 @@
             "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/astral-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/async": {
             "version": "3.2.6",
@@ -6434,13 +6381,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/aws4": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-            "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/axios": {
             "version": "1.17.0",
@@ -6850,14 +6790,16 @@
             "license": "MIT"
         },
         "node_modules/builder-util": {
-            "version": "26.15.0",
-            "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.0.tgz",
-            "integrity": "sha512-dUx+HxVbiNsNQ4mGe1PyoC/tBmsHwBNDLdBuqWCj+rhHFE9lHgrXiGYKAM1uNlznhAaUSyMlms84VeSSr3gOBA==",
+            "version": "26.8.1",
+            "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.8.1.tgz",
+            "integrity": "sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/debug": "^4.1.6",
-                "builder-util-runtime": "9.7.0",
+                "7zip-bin": "~5.2.0",
+                "app-builder-bin": "5.0.0-alpha.12",
+                "builder-util-runtime": "9.5.1",
                 "chalk": "^4.1.2",
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.4",
@@ -6870,9 +6812,20 @@
                 "stat-mode": "^1.0.0",
                 "temp-file": "^3.4.0",
                 "tiny-async-pool": "1.3.0"
+            }
+        },
+        "node_modules/builder-util-runtime": {
+            "version": "9.5.1",
+            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+            "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.4",
+                "sax": "^1.2.4"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=12.0.0"
             }
         },
         "node_modules/builder-util/node_modules/ansi-styles": {
@@ -6889,20 +6842,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/builder-util/node_modules/builder-util-runtime": {
-            "version": "9.7.0",
-            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
-            "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4",
-                "sax": "^1.2.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
             }
         },
         "node_modules/builder-util/node_modules/chalk": {
@@ -6981,16 +6920,6 @@
             "optional": true,
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/bytestreamjs": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
-            "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/cacheable-lookup": {
@@ -7334,6 +7263,24 @@
             "optional": true,
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-truncate": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+            "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "slice-ansi": "^3.0.0",
+                "string-width": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -7766,6 +7713,17 @@
             "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/crc": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+            "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "buffer": "^5.1.0"
+            }
         },
         "node_modules/crc-32": {
             "version": "1.2.2",
@@ -8319,16 +8277,20 @@
             }
         },
         "node_modules/dmg-builder": {
-            "version": "26.15.2",
-            "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.2.tgz",
-            "integrity": "sha512-fMkjRqKyPtsz4Kzu/qGP0BGjqzMCIgp+/7kw/u6YH6lvn/8hvL3c0TXhoFayBoYdpPCnEinnCHztd4bW7/jetA==",
+            "version": "26.8.1",
+            "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.8.1.tgz",
+            "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "app-builder-lib": "26.15.2",
-                "builder-util": "26.15.0",
+                "app-builder-lib": "26.8.1",
+                "builder-util": "26.8.1",
                 "fs-extra": "^10.1.0",
+                "iconv-lite": "^0.6.2",
                 "js-yaml": "^4.1.0"
+            },
+            "optionalDependencies": {
+                "dmg-license": "^1.0.11"
             }
         },
         "node_modules/dmg-builder/node_modules/fs-extra": {
@@ -8367,6 +8329,33 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/dmg-license": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
+            "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "dependencies": {
+                "@types/plist": "^3.0.1",
+                "@types/verror": "^1.10.3",
+                "ajv": "^6.10.0",
+                "crc": "^3.8.0",
+                "iconv-corefoundation": "^1.1.7",
+                "plist": "^3.0.4",
+                "smart-buffer": "^4.0.2",
+                "verror": "^1.10.0"
+            },
+            "bin": {
+                "dmg-license": "bin/dmg-license.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/doctrine": {
@@ -8525,16 +8514,6 @@
             "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
             "license": "MIT"
         },
-        "node_modules/duplexer2": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "readable-stream": "^2.0.2"
-            }
-        },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -8658,18 +8637,18 @@
             }
         },
         "node_modules/electron-builder": {
-            "version": "26.15.2",
-            "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.2.tgz",
-            "integrity": "sha512-veKM9+dCljaC5A74Pwc0ZWQ9arOHREXWh9hUIf8NGg49ch7x+IB4QhbMzIrV5ONZIXM2OEkaxW11cAPjPtoi4A==",
+            "version": "26.8.1",
+            "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.8.1.tgz",
+            "integrity": "sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "app-builder-lib": "26.15.2",
-                "builder-util": "26.15.0",
-                "builder-util-runtime": "9.7.0",
+                "app-builder-lib": "26.8.1",
+                "builder-util": "26.8.1",
+                "builder-util-runtime": "9.5.1",
                 "chalk": "^4.1.2",
                 "ci-info": "^4.2.0",
-                "dmg-builder": "26.15.2",
+                "dmg-builder": "26.8.1",
                 "fs-extra": "^10.1.0",
                 "lazy-val": "^1.0.5",
                 "simple-update-notifier": "2.0.0",
@@ -8684,15 +8663,15 @@
             }
         },
         "node_modules/electron-builder-squirrel-windows": {
-            "version": "26.15.2",
-            "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.2.tgz",
-            "integrity": "sha512-PNl+SSRoma9mXhxycNGxutZPgvmK19v41mn8F9oecpAU2QNAldpB4HfMuA1LwFC2j8aRzzV5M9HKlKe6dfpvNw==",
+            "version": "26.8.1",
+            "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.8.1.tgz",
+            "integrity": "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "app-builder-lib": "26.15.2",
-                "builder-util": "26.15.0",
+                "app-builder-lib": "26.8.1",
+                "builder-util": "26.8.1",
                 "electron-winstaller": "5.4.0"
             }
         },
@@ -8710,20 +8689,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/electron-builder/node_modules/builder-util-runtime": {
-            "version": "9.7.0",
-            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
-            "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4",
-                "sax": "^1.2.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
             }
         },
         "node_modules/electron-builder/node_modules/chalk": {
@@ -8804,16 +8769,15 @@
             }
         },
         "node_modules/electron-publish": {
-            "version": "26.15.1",
-            "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.1.tgz",
-            "integrity": "sha512-BMgMHOyexWn0UnOC+Afffw0DMrr0yfLp4U8YsLXwoJ3Da7LS7WUnz21teYZqO0gaApE1KgsjREWmbPqvF5JcPg==",
+            "version": "26.8.1",
+            "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.8.1.tgz",
+            "integrity": "sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/fs-extra": "^9.0.11",
-                "aws4": "^1.13.2",
-                "builder-util": "26.15.0",
-                "builder-util-runtime": "9.7.0",
+                "builder-util": "26.8.1",
+                "builder-util-runtime": "9.5.1",
                 "chalk": "^4.1.2",
                 "form-data": "^4.0.5",
                 "fs-extra": "^10.1.0",
@@ -8835,20 +8799,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/electron-publish/node_modules/builder-util-runtime": {
-            "version": "9.7.0",
-            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
-            "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4",
-                "sax": "^1.2.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
             }
         },
         "node_modules/electron-publish/node_modules/chalk": {
@@ -10026,6 +9976,17 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/extsprintf": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+            "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+            "dev": true,
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/fast-check": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
@@ -10083,23 +10044,6 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "BSD-3-Clause"
         },
         "node_modules/fast-xml-builder": {
             "version": "1.2.0",
@@ -11499,6 +11443,24 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/typicode"
+            }
+        },
+        "node_modules/iconv-corefoundation": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
+            "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "dependencies": {
+                "cli-truncate": "^2.1.0",
+                "node-addon-api": "^1.6.3"
+            },
+            "engines": {
+                "node": "^8.11.2 || >=10"
             }
         },
         "node_modules/iconv-lite": {
@@ -14439,6 +14401,14 @@
                 "node": ">=22.12.0"
             }
         },
+        "node_modules/node-addon-api": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+            "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/node-api-headers": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/node-api-headers/-/node-api-headers-1.8.0.tgz",
@@ -14516,13 +14486,6 @@
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
-        },
-        "node_modules/node-int64": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-            "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/node-llama-cpp": {
             "version": "3.18.1",
@@ -15597,37 +15560,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/pkijs": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
-            "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@noble/hashes": "1.4.0",
-                "asn1js": "^3.0.6",
-                "bytestreamjs": "^2.0.1",
-                "pvtsutils": "^1.3.6",
-                "pvutils": "^1.1.3",
-                "tslib": "^2.8.1"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/pkijs/node_modules/@noble/hashes": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
         "node_modules/playwright": {
             "version": "1.58.2",
             "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
@@ -16063,26 +15995,6 @@
                 }
             ],
             "license": "MIT"
-        },
-        "node_modules/pvtsutils": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
-            "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.8.1"
-            }
-        },
-        "node_modules/pvutils": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
-            "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=16.0.0"
-            }
         },
         "node_modules/query-selector-shadow-dom": {
             "version": "1.0.1",
@@ -17451,6 +17363,39 @@
             "integrity": "sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA==",
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/slice-ansi": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+            "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/slice-ansi/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
         },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
@@ -18879,58 +18824,6 @@
                 "node": ">= 4.0.0"
             }
         },
-        "node_modules/unzipper": {
-            "version": "0.12.3",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
-            "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bluebird": "~3.7.2",
-                "duplexer2": "~0.1.4",
-                "fs-extra": "^11.2.0",
-                "graceful-fs": "^4.2.2",
-                "node-int64": "^0.4.0"
-            }
-        },
-        "node_modules/unzipper/node_modules/fs-extra": {
-            "version": "11.3.5",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-            "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
-            }
-        },
-        "node_modules/unzipper/node_modules/jsonfile": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/unzipper/node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -19284,6 +19177,22 @@
             "optional": true,
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/verror": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+            "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=0.6.0"
             }
         },
         "node_modules/vite": {
@@ -19694,20 +19603,6 @@
             "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==",
             "dev": true,
             "license": "Apache-2.0"
-        },
-        "node_modules/webcrypto-core": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
-            "integrity": "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@peculiar/asn1-schema": "^2.7.0",
-                "@peculiar/json-schema": "^1.1.12",
-                "@peculiar/utils": "^2.0.2",
-                "asn1js": "^3.0.10",
-                "tslib": "^2.8.1"
-            }
         },
         "node_modules/webdriver": {
             "version": "9.24.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
         "@wdio/types": "^9.23.3",
         "concurrently": "^9.2.1",
         "electron": "^39.8.10",
-        "electron-builder": "^26.15.2",
+        "electron-builder": "26.8.1",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A desktop wrapper for Google Gemini with enhanced features",
     "author": "Ben Wendell <github@benwendell.com>",
     "private": true,
-    "version": "0.12.0",
+    "version": "0.12.1",
     "type": "module",
     "main": "dist-electron/main/main.cjs",
     "keywords": [


### PR DESCRIPTION
## Release v0.12.1

This PR prepares the `v0.12.1` release, focused on Linux startup stability, Linux package metadata cleanup, and post-`v0.12.0` dependency maintenance.

### Key Changes

- Bump app version from `0.12.0` to `0.12.1` in `package.json` and `package-lock.json`.
- Update `docs/ROADMAP.md` with the `v0.12.1` shipped-history entry.
- Summarize Linux startup stability improvements for V8-sandbox-incompatible kernels from [#333](https://github.com/bwendell/gemini-desktop/pull/333).
- Summarize Linux Debian package metadata and appindicator guidance updates from [#332](https://github.com/bwendell/gemini-desktop/pull/332).
- Roll up post-`v0.12.0` dependency and CI maintenance from [#309](https://github.com/bwendell/gemini-desktop/pull/309), [#314](https://github.com/bwendell/gemini-desktop/pull/314), [#320](https://github.com/bwendell/gemini-desktop/pull/320), [#338](https://github.com/bwendell/gemini-desktop/pull/338), [#339](https://github.com/bwendell/gemini-desktop/pull/339), [#340](https://github.com/bwendell/gemini-desktop/pull/340), [#342](https://github.com/bwendell/gemini-desktop/pull/342), [#344](https://github.com/bwendell/gemini-desktop/pull/344), [#345](https://github.com/bwendell/gemini-desktop/pull/345), [#347](https://github.com/bwendell/gemini-desktop/pull/347), and [#348](https://github.com/bwendell/gemini-desktop/pull/348).

### Draft GitHub Release Notes

```markdown
# Release 0.12.1

## What's Changed

### Highlights

- **Linux startup stability**: avoid loading V8-sandbox-incompatible native probes on affected Linux kernels so Gemini Desktop can launch reliably while preserving in-app keyboard shortcuts. Global hotkeys and local text prediction remain unavailable on those kernel paths. (PR [#333](https://github.com/bwendell/gemini-desktop/pull/333))
- **Linux package metadata refresh**: remove deprecated Debian dependencies, recommend Ayatana AppIndicator support, and document current appindicator guidance for modern Linux distributions. (PR [#332](https://github.com/bwendell/gemini-desktop/pull/332))

### Maintenance

- **Dependency and CI refresh**: update post-0.12.0 runtime, Electron, testing, React type, YAML, CodeQL, and markdown-rendering dependencies. (PR [#309](https://github.com/bwendell/gemini-desktop/pull/309), PR [#314](https://github.com/bwendell/gemini-desktop/pull/314), PR [#320](https://github.com/bwendell/gemini-desktop/pull/320), PR [#338](https://github.com/bwendell/gemini-desktop/pull/338), PR [#339](https://github.com/bwendell/gemini-desktop/pull/339), PR [#340](https://github.com/bwendell/gemini-desktop/pull/340), PR [#342](https://github.com/bwendell/gemini-desktop/pull/342), PR [#344](https://github.com/bwendell/gemini-desktop/pull/344), PR [#345](https://github.com/bwendell/gemini-desktop/pull/345), PR [#347](https://github.com/bwendell/gemini-desktop/pull/347), PR [#348](https://github.com/bwendell/gemini-desktop/pull/348))

## Installation

| Platform | Download |
| --- | --- |
| Windows x64 | `Gemini-Desktop-0.12.1-x64-installer.exe` |
| Windows ARM64 | `Gemini-Desktop-0.12.1-arm64-installer.exe` |
| macOS Intel | `Gemini-Desktop-0.12.1-x64.dmg` |
| macOS Apple Silicon | `Gemini-Desktop-0.12.1-arm64.dmg` |
| Linux AppImage | `Gemini-Desktop-0.12.1-x64.AppImage` |

---

**Full Changelog**: https://github.com/bwendell/gemini-desktop/compare/v0.12.0...v0.12.1
```

### Verification

- `node -e` version check confirmed `package.json`, root `package-lock.json`, and lockfile package metadata are all `0.12.1`.
- `npm run lint` passed.
- `npm run test` passed: 56 files, 651 tests passed, 4 skipped.
- Pre-commit hook reran Prettier on staged files and `npm run lint` successfully before creating the release commit.

### Notes

- Existing `v0.12.1-appimage-rc1` and `v0.12.1-appimage-rc2` tags were treated as prerelease validation tags; the previous stable release baseline for these notes is `v0.12.0`.
